### PR TITLE
fix: sort OpenCode and Gemini CLI plugins alphabetically

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
   "source": "awesome-ai-plugins",
-  "last_updated": "2026-04-08T08:18:13.131121+00:00",
+  "last_updated": "2026-04-08T09:53:00.039776+00:00",
   "plugins": [
     {
       "name": "Agent Message Queue",
@@ -382,10 +382,19 @@
       "source": "awesome-ai-plugins"
     },
     {
+      "name": "Oh My Claude",
+      "url": "https://github.com/2lab-ai/oh-my-claude",
+      "owner": "2lab-ai",
+      "repo": "oh-my-claude",
+      "description": "Claude Code plugin for AI-powered iterative development loops",
+      "platform": "claude-code",
+      "source": "awesome-ai-plugins"
+    },
+    {
       "name": "OpenCode",
       "url": "https://opencode.com",
-      "owner": "schuettc",
-      "repo": "codex-reviewer",
+      "owner": "2lab-ai",
+      "repo": "oh-my-claude",
       "description": "OpenAI's AI coding CLI",
       "platform": "opencode",
       "source": "awesome-ai-plugins"
@@ -405,6 +414,15 @@
       "owner": "boshu2",
       "repo": "agentops",
       "description": "DevOps layer for coding agents with flow, feedback, and memory",
+      "platform": "opencode",
+      "source": "awesome-ai-plugins"
+    },
+    {
+      "name": "AI Plugin Scanner",
+      "url": "https://github.com/hashgraph-online/ai-plugin-scanner",
+      "owner": "hashgraph-online",
+      "repo": "ai-plugin-scanner",
+      "description": "Security and best-practices scanner for AI plugins",
       "platform": "opencode",
       "source": "awesome-ai-plugins"
     },
@@ -576,6 +594,15 @@
       "owner": "BlockchainHB",
       "repo": "launchfast_codex_plugin",
       "description": "Official Launch Fast plugin adapter for rapid SaaS deployment",
+      "platform": "opencode",
+      "source": "awesome-ai-plugins"
+    },
+    {
+      "name": "MCD Agent Toolkit",
+      "url": "https://github.com/monte-carlo-data/mcd-agent-toolkit",
+      "owner": "monte-carlo-data",
+      "repo": "mcd-agent-toolkit",
+      "description": "Official Monte Carlo toolkit for AI coding agents",
       "platform": "opencode",
       "source": "awesome-ai-plugins"
     },
@@ -814,6 +841,15 @@
       "source": "awesome-ai-plugins"
     },
     {
+      "name": "Code Review",
+      "url": "https://github.com/gemini-cli-extensions/code-review",
+      "owner": "gemini-cli-extensions",
+      "repo": "code-review",
+      "description": "AI-powered code review for Gemini CLI",
+      "platform": "gemini-cli",
+      "source": "awesome-ai-plugins"
+    },
+    {
       "name": "Codex Agenteam",
       "url": "https://github.com/yimwoo/codex-agenteam",
       "owner": "yimwoo",
@@ -855,6 +891,15 @@
       "owner": "BestLemoon",
       "repo": "codex-seo",
       "description": "Full-stack SEO audits, Google API workflows, backlinks analysis, reporting, and optional MCP extensions for Codex",
+      "platform": "gemini-cli",
+      "source": "awesome-ai-plugins"
+    },
+    {
+      "name": "Conductor",
+      "url": "https://github.com/gemini-cli-extensions/conductor",
+      "owner": "gemini-cli-extensions",
+      "repo": "conductor",
+      "description": "Specify, plan, and implement multi-step tasks",
       "platform": "gemini-cli",
       "source": "awesome-ai-plugins"
     },
@@ -999,6 +1044,15 @@
       "owner": "talkstream",
       "repo": "ru-text",
       "description": "Russian text quality \u2014 ~1,040 rules for typography, info-style, editorial, UX writing, and business correspondence",
+      "platform": "gemini-cli",
+      "source": "awesome-ai-plugins"
+    },
+    {
+      "name": "Security",
+      "url": "https://github.com/gemini-cli-extensions/security",
+      "owner": "gemini-cli-extensions",
+      "repo": "security",
+      "description": "Find vulnerabilities in code with Google security tools",
       "platform": "gemini-cli",
       "source": "awesome-ai-plugins"
     },

--- a/README.md
+++ b/README.md
@@ -162,10 +162,9 @@ _Contributions welcome - submit via PR_
 
 - [Agent Message Queue](https://github.com/avivsinai/agent-message-queue) - File-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations.
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory.
+- [AI Plugin Scanner](https://github.com/hashgraph-online/ai-plugin-scanner) - Security and best-practices scanner for AI plugins.
 - [Apple Productivity](https://github.com/matk0shub/apple-productivity-mcp) - Local Apple Calendar and Reminders for macOS.
 - [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) - Manage Bitbucket repos, PRs, and pipelines.
-- [AI Plugin Scanner](https://github.com/hashgraph-online/ai-plugin-scanner) - Security and best-practices scanner for AI plugins.
-- [MCD Agent Toolkit](https://github.com/monte-carlo-data/mcd-agent-toolkit) - Official Monte Carlo toolkit for AI coding agents.
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) - Specification-driven development pipeline with testable acceptance criteria.
 - [Brooks Lint](https://github.com/hyhmrright/brooks-lint) - AI code reviews grounded in six classic engineering books.
 - [Chrome DevTools](https://github.com/win4r/chrome-devtools-codex-plugin) - One-click Codex plugin wrapper for chrome-devtools-mcp.
@@ -183,6 +182,7 @@ _Contributions welcome - submit via PR_
 - [KiCad Happy](https://github.com/aklofas/kicad-happy) - KiCad EDA skills for schematic analysis, PCB layout review, component sourcing, BOM management, and manufacturing preparation.
 - [Langfuse Observability](https://github.com/avivsinai/langfuse-mcp) - Query traces, debug exceptions, analyze sessions.
 - [Launch Fast](https://github.com/BlockchainHB/launchfast_codex_plugin) - Official Launch Fast plugin adapter for rapid SaaS deployment.
+- [MCD Agent Toolkit](https://github.com/monte-carlo-data/mcd-agent-toolkit) - Official Monte Carlo toolkit for AI coding agents.
 - [OC ChatGPT Multi Auth](https://github.com/ndycode/oc-chatgpt-multi-auth) - Codex setup skill and OpenCode plugin for ChatGPT Plus/Pro OAuth, GPT-5/Codex presets, and multi-account failover.
 - [OpenProject](https://github.com/varaprasadreddy9676/team-codex-plugins) - Team collaboration via OpenProject integration.
 - [OrgX](https://github.com/useorgx/orgx-codex-plugin) - MCP access and initiative-aware skills for organizational workflows.
@@ -219,19 +219,18 @@ _Contributions welcome - submit via PR_
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory.
 - [Apple Productivity](https://github.com/matk0shub/apple-productivity-mcp) - Local Apple Calendar and Reminders for macOS.
 - [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) - Manage Bitbucket repos, PRs, and pipelines.
-- [Code Review](https://github.com/gemini-cli-extensions/code-review) - AI-powered code review for Gemini CLI.
-- [Conductor](https://github.com/gemini-cli-extensions/conductor) - Specify, plan, and implement multi-step tasks.
-- [Security](https://github.com/gemini-cli-extensions/security) - Find vulnerabilities in code with Google security tools.
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) - Specification-driven development pipeline with testable acceptance criteria.
 - [Brooks Lint](https://github.com/hyhmrright/brooks-lint) - AI code reviews grounded in six classic engineering books.
 - [Chrome DevTools](https://github.com/win4r/chrome-devtools-codex-plugin) - One-click Codex plugin wrapper for chrome-devtools-mcp.
 - [Claude Code for Codex](https://github.com/sendbird/cc-plugin-codex) - Use Claude Code from Codex for reviews and rescue tasks.
 - [Claude Octopus](https://github.com/nyldn/claude-octopus) - Multi-LLM orchestration dispatching to 8 providers.
+- [Code Review](https://github.com/gemini-cli-extensions/code-review) - AI-powered code review for Gemini CLI.
 - [Codex Agenteam](https://github.com/yimwoo/codex-agenteam) - Specialist AI agents orchestrated as a configurable team pipeline.
 - [Codex Be Serious](https://github.com/lulucatdev/codex-be-serious) - Enforce formal, textbook-grade written register across all agent output.
 - [Codex Mem](https://github.com/2kDarki/codex-mem) - Automatically capture, compress, and inject session context back into future Codex sessions.
 - [Codex Multi Auth](https://github.com/ndycode/codex-multi-auth) - Multi-account OAuth manager for the official Codex CLI with switching, health checks, and recovery tools.
 - [Codex SEO](https://github.com/BestLemoon/codex-seo) - Full-stack SEO audits, Google API workflows, backlinks analysis, reporting, and optional MCP extensions for Codex.
+- [Conductor](https://github.com/gemini-cli-extensions/conductor) - Specify, plan, and implement multi-step tasks.
 - [Context Pack](https://github.com/Rothschildiuk/context-pack) - Generate compact first-pass repository briefings for coding agents before deeper exploration.
 - [Flow Studio Power Automate](https://github.com/ninihen1/power-automate-mcp-skills) - Debug, build, and operate Power Automate flows via FlowStudio MCP with action-level inputs and outputs.
 - [HOTL Plugin](https://github.com/yimwoo/hotl-plugin) - Human-on-the-Loop AI coding workflow plugin.
@@ -248,6 +247,7 @@ _Contributions welcome - submit via PR_
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry.
 - [Remotion Plugin](https://github.com/tim-osterhus/codex-remotion-plugin) - Build parameterized Remotion videos in Codex.
 - [ru-text](https://github.com/talkstream/ru-text) - Russian text quality — ~1,040 rules for typography, info-style, editorial, UX writing, and business correspondence.
+- [Security](https://github.com/gemini-cli-extensions/security) - Find vulnerabilities in code with Google security tools.
 - [sitemd](https://github.com/sitemd-cc/sitemd) - Build websites from Markdown via MCP — 22 tools for creating pages, generating content, validating, running SEO audits, configuring settings, and deploying static sites to Cloudflare Pages.
 - [Synta MCP](https://github.com/Synta-ai/n8n-mcp-codex-plugin-synta) - Build, edit, validate, and self-heal n8n workflows with Synta MCP tools and Codex-ready workflow guidance.
 - [Task Scheduler](https://github.com/6Delta9/task-scheduler-codex-plugin) - OpenAI Codex plugin and local MCP server for turning task lists into realistic schedules with blocked dates, capacity overrides, overflow tracking, and markdown planning output.

--- a/plugins.json
+++ b/plugins.json
@@ -3,7 +3,7 @@
   "name": "awesome-ai-plugins",
   "version": "1.0.0",
   "last_updated": "2026-04-08",
-  "total": 138,
+  "total": 144,
   "platforms": [
     "codex",
     "claude-code",
@@ -391,10 +391,19 @@
       "source": "awesome-ai-plugins"
     },
     {
+      "name": "Oh My Claude",
+      "url": "https://github.com/2lab-ai/oh-my-claude",
+      "owner": "2lab-ai",
+      "repo": "oh-my-claude",
+      "description": "Claude Code plugin for AI-powered iterative development loops",
+      "platform": "claude-code",
+      "source": "awesome-ai-plugins"
+    },
+    {
       "name": "OpenCode",
       "url": "https://opencode.com",
-      "owner": "schuettc",
-      "repo": "codex-reviewer",
+      "owner": "2lab-ai",
+      "repo": "oh-my-claude",
       "description": "OpenAI's AI coding CLI",
       "platform": "opencode",
       "source": "awesome-ai-plugins"
@@ -414,6 +423,15 @@
       "owner": "boshu2",
       "repo": "agentops",
       "description": "DevOps layer for coding agents with flow, feedback, and memory",
+      "platform": "opencode",
+      "source": "awesome-ai-plugins"
+    },
+    {
+      "name": "AI Plugin Scanner",
+      "url": "https://github.com/hashgraph-online/ai-plugin-scanner",
+      "owner": "hashgraph-online",
+      "repo": "ai-plugin-scanner",
+      "description": "Security and best-practices scanner for AI plugins",
       "platform": "opencode",
       "source": "awesome-ai-plugins"
     },
@@ -585,6 +603,15 @@
       "owner": "BlockchainHB",
       "repo": "launchfast_codex_plugin",
       "description": "Official Launch Fast plugin adapter for rapid SaaS deployment",
+      "platform": "opencode",
+      "source": "awesome-ai-plugins"
+    },
+    {
+      "name": "MCD Agent Toolkit",
+      "url": "https://github.com/monte-carlo-data/mcd-agent-toolkit",
+      "owner": "monte-carlo-data",
+      "repo": "mcd-agent-toolkit",
+      "description": "Official Monte Carlo toolkit for AI coding agents",
       "platform": "opencode",
       "source": "awesome-ai-plugins"
     },
@@ -823,6 +850,15 @@
       "source": "awesome-ai-plugins"
     },
     {
+      "name": "Code Review",
+      "url": "https://github.com/gemini-cli-extensions/code-review",
+      "owner": "gemini-cli-extensions",
+      "repo": "code-review",
+      "description": "AI-powered code review for Gemini CLI",
+      "platform": "gemini-cli",
+      "source": "awesome-ai-plugins"
+    },
+    {
       "name": "Codex Agenteam",
       "url": "https://github.com/yimwoo/codex-agenteam",
       "owner": "yimwoo",
@@ -864,6 +900,15 @@
       "owner": "BestLemoon",
       "repo": "codex-seo",
       "description": "Full-stack SEO audits, Google API workflows, backlinks analysis, reporting, and optional MCP extensions for Codex",
+      "platform": "gemini-cli",
+      "source": "awesome-ai-plugins"
+    },
+    {
+      "name": "Conductor",
+      "url": "https://github.com/gemini-cli-extensions/conductor",
+      "owner": "gemini-cli-extensions",
+      "repo": "conductor",
+      "description": "Specify, plan, and implement multi-step tasks",
       "platform": "gemini-cli",
       "source": "awesome-ai-plugins"
     },
@@ -1008,6 +1053,15 @@
       "owner": "talkstream",
       "repo": "ru-text",
       "description": "Russian text quality \u2014 ~1,040 rules for typography, info-style, editorial, UX writing, and business correspondence",
+      "platform": "gemini-cli",
+      "source": "awesome-ai-plugins"
+    },
+    {
+      "name": "Security",
+      "url": "https://github.com/gemini-cli-extensions/security",
+      "owner": "gemini-cli-extensions",
+      "repo": "security",
+      "description": "Find vulnerabilities in code with Google security tools",
       "platform": "gemini-cli",
       "source": "awesome-ai-plugins"
     },


### PR DESCRIPTION
## Summary

Fixes the alphabetical ordering in two sections and regenerates machine-readable artifacts.

- **OpenCode Community Plugins**: AI Plugin Scanner moved between AgentOps and Apple Productivity; MCD Agent Toolkit moved after Launch Fast
- **Gemini CLI Community Plugins**: Code Review moved after Claude Octopus; Conductor moved after Codex SEO; Security moved after ru-text
- Regenerated `plugins.json` and `.agents/plugins/marketplace.json`

Fixes review feedback on #4.