### PR TITLE
Add EnvCP MCP server to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ Model Context Protocol (MCP) servers work across multiple AI assistants that sup
 - [Filesystem](https://github.com/modelcontextprotocol/server-filesystem) - Read and write to local filesystem.
 - [GitHub](https://github.com/modelcontextprotocol/server-github) - Manage GitHub repos, issues, PRs.
 
+#### Security
+
+- [EnvCP](https://github.com/fentz26/EnvCP) - Encrypted environment variable vault with AI access policies, keeping secrets safe from AI agents.
+
 #### Data & APIs
 
 - [Google Maps](https://github.com/modelcontextprotocol/server-google-maps) - Location and mapping services.


### PR DESCRIPTION
## Summary

- Adds [EnvCP](https://github.com/fentz26/EnvCP) under a new **Security** subsection in Popular MCP Servers
- EnvCP is an encrypted environment variable vault with AI access policies — lets you control exactly which secrets AI agents can see and use

## Entry

```
- [EnvCP](https://github.com/fentz26/EnvCP) - Encrypted environment variable vault with AI access policies, keeping secrets safe from AI agents.
```

## Verification

- Active repo with recent releases (v1.0.72 as of today)
- Published on npm: `npm install -g @fentz26/envcp`
- Works with Claude Code, Claude Desktop, and any MCP-compatible client