### PR TITLE
Add Paper Pilot to Community Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Third-party plugins built by the community.
 - [OrgX](https://github.com/useorgx/orgx-codex-plugin) - MCP access and initiative-aware skills for organizational workflows.
 - [PANews Agent Toolkit](https://github.com/panewslab/skills) - Crypto and blockchain news discovery, authenticated creator publishing workflows, and page-to-Markdown reading.
 - [PapersFlow](https://github.com/papersflow-ai/papersflow-codex-plugin) - Paper discovery, citation verification, graph exploration, and DeepScan analysis.
+- [Paper Pilot](https://github.com/aytzey/paper-pilot) - Academic research copilot that searches 6 databases, downloads real PDFs, extracts evidence, renders figures, and syncs to Zotero.
 - [Project Autopilot](https://github.com/AlexMi64/codex-project-autopilot) - Turn an idea into a structured project workflow with planning, execution, verification, and handoff.
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry.
 - [Remotion Plugin](https://github.com/tim-osterhus/codex-remotion-plugin) - Build parameterized Remotion videos in Codex.


### PR DESCRIPTION
## Summary

Adds [Paper Pilot](https://github.com/aytzey/paper-pilot) to the Codex Community Plugins section.

Paper Pilot is an MCP server that gives AI agents real academic research capabilities:

- Searches 6 academic databases (Semantic Scholar, OpenAlex, arXiv, Crossref, Europe PMC, Unpaywall)
- Downloads open-access PDFs and reads them cover to cover
- Extracts evidence chunks with page-level citations
- Renders figures and tables to PNG
- Syncs everything to Zotero

Works with Claude Desktop, Claude Code, Codex, and any MCP client. Free, MIT licensed.

- **Repository:** https://github.com/aytzey/paper-pilot
- **Install:** `uvx paper-pilot` or `pip install paper-pilot`
- **Verified:** Tests pass, package builds clean, v0.4.0 released