### PR TITLE
add BikeScout MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Third-party plugins built by the community.
 - [Agent Message Queue](https://github.com/avivsinai/agent-message-queue) - File-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations.
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory.
 - [Apple Productivity](https://github.com/matk0shub/apple-productivity-mcp) - Local Apple Calendar and Reminders for macOS.
-- [BikeScout](https://github.com/hifly81/bikescout) - Specialized MCP server designed for cyclists and mountain bikers. It provides intelligent trail recommendations by combining real-world map data with advanced routing analysis.
+- [BikeScout](https://github.com/hifly81/bikescout) - Specialized MCP server for technical cycling providing terrain-aware routing, predictive mud-risk analysis, and UCI-standard climb categorization.
 - [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) - Manage Bitbucket repos, PRs, and pipelines.
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) - Specification-driven development pipeline with testable acceptance criteria.
 - [Brooks Lint](https://github.com/hyhmrright/brooks-lint) - AI code reviews grounded in six classic engineering books.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Third-party plugins built by the community.
 - [Agent Message Queue](https://github.com/avivsinai/agent-message-queue) - File-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations.
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory.
 - [Apple Productivity](https://github.com/matk0shub/apple-productivity-mcp) - Local Apple Calendar and Reminders for macOS.
+- [BikeScout](https://github.com/hifly81/bikescout) - Specialized MCP server designed for cyclists and mountain bikers. It provides intelligent trail recommendations by combining real-world map data with advanced routing analysis.
 - [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) - Manage Bitbucket repos, PRs, and pipelines.
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) - Specification-driven development pipeline with testable acceptance criteria.
 - [Brooks Lint](https://github.com/hyhmrright/brooks-lint) - AI code reviews grounded in six classic engineering books.


### PR DESCRIPTION
BikeScout: An MCP server for technical cycling that provides terrain-aware routing, predictive mud-risk analysis, and UCI-standard climb categorization.

Version: 0.8.2 (Stable)

Performance: Successfully handles multi-tool workflows (geocoding + routing + POI scouting) and generates valid GPX outputs and static map previews.

Status: All core dependencies (ORS API, Nominatim, Overpass) are verified and active.

Maintenance Check

Activity: Frequent commits and releases within the last 30 days.

License: Apache 2.0.

Documentation: Fully documented README with installation guides and JSON configuration examples.