### PR TITLE
feat: add oh-my-forge to Claude Code Plugins

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
   "source": "awesome-ai-plugins",
-  "last_updated": "2026-04-10T19:23:51.715587+00:00",
+  "last_updated": "2026-04-11T18:15:45.950374+00:00",
   "plugins": [
     {
       "name": "Agent Message Queue",
@@ -343,6 +343,15 @@
       "repo": "yandex-direct-for-all",
       "description": "GitHub-ready Codex plugin bundle for Yandex Direct, Wordstat, Metrika, and Roistat",
       "platform": "codex",
+      "source": "awesome-ai-plugins"
+    },
+    {
+      "name": "oh-my-forge",
+      "url": "https://github.com/rlagycks/oh-my-forge",
+      "owner": "rlagycks",
+      "repo": "oh-my-forge",
+      "description": "Claude Code plugin with ontology-driven guardrails and harness-engineered agent workflows for TDD, planning, code review, and CI automation",
+      "platform": "claude-code",
       "source": "awesome-ai-plugins"
     },
     {

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Claude Code extends Anthropic's CLI with custom plugins. Official plugins: [anth
 - [code-review](https://github.com/anthropics/claude-code/tree/main/plugins/code-review) - Automated PR code review using multiple specialized agents with confidence-based scoring to filter false positives.
 - [commit-commands](https://github.com/anthropics/claude-code/tree/main/plugins/commit-commands) - Git workflow automation for committing, pushing, and creating pull requests.
 - [feature-dev](https://github.com/anthropics/claude-code/tree/main/plugins/feature-dev) - Comprehensive feature development workflow with a structured 7-phase approach.
+- [oh-my-forge](https://github.com/rlagycks/oh-my-forge) - Claude Code plugin with ontology-driven guardrails and harness-engineered agent workflows for TDD, planning, code review, and CI automation.
 - [Zotero Fulltext](https://github.com/statzhero/zotero-fulltext) - Search and read your Zotero library with citekey lookup and fulltext access.
 
 ---

--- a/plugins.json
+++ b/plugins.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "name": "awesome-ai-plugins",
   "version": "1.0.0",
-  "last_updated": "2026-04-10",
-  "total": 78,
+  "last_updated": "2026-04-12",
+  "total": 79,
   "platforms": [
     "codex",
     "claude-code",
@@ -351,6 +351,15 @@
       "repo": "yandex-direct-for-all",
       "description": "GitHub-ready Codex plugin bundle for Yandex Direct, Wordstat, Metrika, and Roistat",
       "platform": "codex",
+      "source": "awesome-ai-plugins"
+    },
+    {
+      "name": "oh-my-forge",
+      "url": "https://github.com/rlagycks/oh-my-forge",
+      "owner": "rlagycks",
+      "repo": "oh-my-forge",
+      "description": "Claude Code plugin with ontology-driven guardrails and harness-engineered agent workflows for TDD, planning, code review, and CI automation",
+      "platform": "claude-code",
       "source": "awesome-ai-plugins"
     },
     {


### PR DESCRIPTION
## Summary

Adds [oh-my-forge](https://github.com/rlagycks/oh-my-forge) to the Claude Code Plugins section.

- Claude Code plugin with ontology-driven guardrails and harness-engineered agent workflows
- Covers TDD, planning, code review, and CI automation
- 100+ agents, skills, hooks, and commands for the full dev lifecycle

## Verification

- Repository is actively maintained with recent releases (v1.10.1)
- Installable via `/plugin install rlagycks/oh-my-forge`
- CI passing