### PR TITLE
Add immich-photo-manager to Claude Code Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Claude Code extends Anthropic's CLI with custom plugins. Official plugins: [anth
 - [code-review](https://github.com/anthropics/claude-code/tree/main/plugins/code-review) - Automated PR code review using multiple specialized agents with confidence-based scoring to filter false positives.
 - [commit-commands](https://github.com/anthropics/claude-code/tree/main/plugins/commit-commands) - Git workflow automation for committing, pushing, and creating pull requests.
 - [feature-dev](https://github.com/anthropics/claude-code/tree/main/plugins/feature-dev) - Comprehensive feature development workflow with a structured 7-phase approach.
+- [immich-photo-manager](https://github.com/drolosoft/immich-photo-manager) - MCP server for intelligent photo management with Immich — search, geographic album curation, library cleanup, duplicate detection, and interactive HTML galleries.
 - [Zotero Fulltext](https://github.com/statzhero/zotero-fulltext) - Search and read your Zotero library with citekey lookup and fulltext access.
 
 ---


### PR DESCRIPTION
## Summary

Adds [immich-photo-manager](https://github.com/drolosoft/immich-photo-manager) to the **Claude Code Plugins** section — the first MCP server purpose-built for self-hosted photo library management.

If you run [Immich](https://immich.app) and your library has grown past what you can manage by hand, this plugin gives Claude direct access to your instance: natural language search via CLIP, geographic album curation from GPS data, duplicate detection with perceptual hashing, library health reports, and interactive HTML galleries you can browse offline.

- **21 MCP tools** — assets, albums, search, sharing, thumbnails, config
- **11 specialized skills** — end-to-end workflows for cleanup, travel maps, metadata repair, and more
- **Plugin scanner score: 100/100 (A - Excellent)** — zero findings

```
Final Score: 100/100 (A - Excellent)
Findings: critical:0, high:0, medium:0, low:0, info:0
```

## Why this belongs here

The Claude Code Plugins section currently has 4 entries (3 official + 1 community). This would be the 2nd community plugin and the first one focused on a specific self-hosted application domain rather than general developer workflows.

## Checklist

- [x] Not a duplicate — searched existing entries
- [x] Plugin works and is verified
- [x] Follows entry format: `- [Name](URL) - Description.`
- [x] Alphabetical order within section (between `feature-dev` and `Zotero Fulltext`)
- [x] Repository is active with recent commits
- [x] Plugin scanner validation passes (100/100)