### PR TITLE
feat: add claude-ops — business operating system for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Third-party plugins built by the community.
 
 Claude Code extends Anthropic's CLI with custom plugins. Official plugins: [anthropics/claude-code](https://github.com/anthropics/claude-code)
 
+- [claude-ops](https://github.com/Lifecycle-Innovations-Limited/claude-ops) - Business operating system for Claude Code — morning briefing, unified inbox (Slack/Telegram/WhatsApp/Gmail), autonomous PR merge pipeline, production incident dashboard, AWS cost tracking, and YOLO autonomous mode with 4 parallel C-suite agents. 14 slash commands, 9 agents.
 - [code-review](https://github.com/anthropics/claude-code/tree/main/plugins/code-review) - Automated PR code review using multiple specialized agents with confidence-based scoring to filter false positives.
 - [commit-commands](https://github.com/anthropics/claude-code/tree/main/plugins/commit-commands) - Git workflow automation for committing, pushing, and creating pull requests.
 - [feature-dev](https://github.com/anthropics/claude-code/tree/main/plugins/feature-dev) - Comprehensive feature development workflow with a structured 7-phase approach.


### PR DESCRIPTION
## Summary

Adds [claude-ops](https://github.com/Lifecycle-Innovations-Limited/claude-ops) to the Claude Code Plugins section.

**What it is**: A Claude Code plugin that turns Claude Code into a complete business operating system. One command (`/ops:go`) delivers a morning briefing covering infrastructure health, CI/CD status, unread messages, open PRs, sprint state, and AWS cost snapshot.

**Install**:
```bash
/plugin marketplace add Lifecycle-Innovations-Limited/claude-ops
/plugin install ops@lifecycle-innovations-limited-claude-ops
```

**Key commands**: `/ops:go`, `/ops:inbox`, `/ops:merge`, `/ops:fires`, `/ops:revenue`, `/ops:yolo`

**Integrations**: GitHub, Linear, Sentry, AWS, Slack, Telegram, WhatsApp, Gmail, Vercel

**License**: MIT
