### PR TITLE
Add MorningAI to Claude Code Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Claude Code extends Anthropic's CLI with custom plugins. Official plugins: [anth
 - [feature-dev](https://github.com/anthropics/claude-code/tree/main/plugins/feature-dev) - Comprehensive feature development workflow with a structured 7-phase approach.
 - [immich-photo-manager](https://github.com/drolosoft/immich-photo-manager) - MCP server for intelligent photo management with Immich — search, geographic album curation, library cleanup, duplicate detection, and interactive HTML galleries.
 - [Lastest](https://github.com/las-team/lastest) - Self-hosted visual regression testing platform with AI-generated tests, MCP server integration, and collaborative diff review.
+- [MorningAI](https://github.com/octo-patch/MorningAI) - AI news tracking skill that monitors 80+ entities across 6 sources (Reddit, HN, GitHub, HuggingFace, arXiv, X), generates scored daily reports with infographics and message digests.
 - [oh-my-forge](https://github.com/rlagycks/oh-my-forge) - Claude Code plugin with ontology-driven guardrails and harness-engineered agent workflows for TDD, planning, code review, and CI automation.
 - [SocratiCode](https://github.com/giancarloerra/SocratiCode) - Codebase intelligence MCP server with semantic search, dependency graph analysis, and context artifact exploration.
 - [Zotero Fulltext](https://github.com/statzhero/zotero-fulltext) - Search and read your Zotero library with citekey lookup and fulltext access.


### PR DESCRIPTION
## Summary

- Adds [MorningAI](https://github.com/octo-patch/MorningAI) to **Claude Code Plugins** section
- AI news tracking skill that monitors 80+ entities across 6 sources (Reddit, HN, GitHub, HuggingFace, arXiv, X), generates scored daily reports with infographics and message digests
- Includes `.claude-plugin/plugin.json` manifest
- Entry placed in alphabetical order