### PR TITLE
Add Obsidian Vault plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Third-party plugins built by the community.
 - [Langfuse Observability](https://github.com/avivsinai/langfuse-mcp) - Query traces, debug exceptions, analyze sessions.
 - [Launch Fast](https://github.com/BlockchainHB/launchfast_codex_plugin) - Official Launch Fast plugin adapter for rapid SaaS deployment.
 - [OC ChatGPT Multi Auth](https://github.com/ndycode/oc-chatgpt-multi-auth) - Codex setup skill and OpenCode plugin for ChatGPT Plus/Pro OAuth, GPT-5/Codex presets, and multi-account failover.
+- [Obsidian Vault](https://github.com/luffysolution-svg/obsidian-vault-mcp) - Maintain local Obsidian vaults as linked wikis with MCP tools for files, frontmatter, wikilinks, Canvas/Bases, and source ingestion.
 - [OpenProject](https://github.com/varaprasadreddy9676/team-codex-plugins) - Team collaboration via OpenProject integration.
 - [OrgX](https://github.com/useorgx/orgx-codex-plugin) - MCP access and initiative-aware skills for organizational workflows.
 - [PANews Agent Toolkit](https://github.com/panewslab/skills) - Crypto and blockchain news discovery, authenticated creator publishing workflows, and page-to-Markdown reading.


### PR DESCRIPTION
## Summary

Adds Obsidian Vault to the OpenAI Codex Plugins community list.

## Extension

- Repository: https://github.com/luffysolution-svg/obsidian-vault-mcp
- Category: OpenAI Codex Plugins / Community Plugins
- Format: one-line README entry, inserted alphabetically between OC ChatGPT Multi Auth and OpenProject

## Verification

- Confirmed the target repository is public and recently active.
- Confirmed `README.md` entry format and alphabetical placement locally.
- `python -m pipx run codex-plugin-scanner lint .` in this awesome list repo: policy pass.
- `python -m pipx run codex-plugin-scanner verify .` in this awesome list repo currently fails on existing marketplace metadata warnings unrelated to this README-only entry.
- `python -m pipx run codex-plugin-scanner lint .` in the Obsidian Vault plugin repo: policy pass.
- `python -m pipx run codex-plugin-scanner verify .` in the Obsidian Vault plugin repo hit a local Windows scanner/runtime issue while checking MCP stdio (`server did not respond to initialize`, followed by a GBK stderr decode error).