### PR TITLE
Add Dodo Payments to Codex, Claude Code, and OpenCode plugin sections

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
   "source": "awesome-ai-plugins",
-  "last_updated": "2026-05-02T13:11:20.929065+00:00",
+  "last_updated": "2026-05-10T04:19:46.252498+00:00",
   "plugins": [
     {
       "name": "Agent Message Queue",
@@ -144,6 +144,15 @@
       "owner": "Rothschildiuk",
       "repo": "context-pack",
       "description": "Generate compact first-pass repository briefings for coding agents before deeper exploration",
+      "platform": "codex",
+      "source": "awesome-ai-plugins"
+    },
+    {
+      "name": "Dodo Payments",
+      "url": "https://github.com/dodopayments/dodo-agent-plugin",
+      "owner": "dodopayments",
+      "repo": "dodo-agent-plugin",
+      "description": "Payments integration for checkouts, subscriptions, and billing with live API and documentation MCP servers with browser OAuth",
       "platform": "codex",
       "source": "awesome-ai-plugins"
     },
@@ -418,6 +427,15 @@
       "source": "awesome-ai-plugins"
     },
     {
+      "name": "Dodo Payments",
+      "url": "https://github.com/dodopayments/dodo-agent-plugin",
+      "owner": "dodopayments",
+      "repo": "dodo-agent-plugin",
+      "description": "Payments integration for checkouts, subscriptions, and billing with live API and documentation MCP servers with browser OAuth",
+      "platform": "claude-code",
+      "source": "awesome-ai-plugins"
+    },
+    {
       "name": "feature-dev",
       "url": "https://github.com/anthropics/claude-code/tree/main/plugins/feature-dev",
       "owner": "anthropics",
@@ -513,6 +531,15 @@
       "owner": "hashgraph-online",
       "repo": "ai-plugin-scanner",
       "description": "Security and best-practices scanner for AI plugins",
+      "platform": "opencode",
+      "source": "awesome-ai-plugins"
+    },
+    {
+      "name": "Dodo Payments",
+      "url": "https://github.com/dodopayments/dodo-agent-plugin",
+      "owner": "dodopayments",
+      "repo": "dodo-agent-plugin",
+      "description": "Payments integration for checkouts, subscriptions, and billing with live API and documentation MCP servers with browser OAuth",
       "platform": "opencode",
       "source": "awesome-ai-plugins"
     },

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Third-party plugins built by the community.
 - [Codex Multi Auth](https://github.com/ndycode/codex-multi-auth) - Multi-account OAuth manager for the official Codex CLI with switching, health checks, and recovery tools.
 - [Codex SEO](https://github.com/BestLemoon/codex-seo) - Full-stack SEO audits, Google API workflows, backlinks analysis, reporting, and optional MCP extensions for Codex.
 - [Context Pack](https://github.com/Rothschildiuk/context-pack) - Generate compact first-pass repository briefings for coding agents before deeper exploration.
+- [Dodo Payments](https://github.com/dodopayments/dodo-agent-plugin) - Payments integration for checkouts, subscriptions, and billing with live API and documentation MCP servers with browser OAuth.
 - [Flow Studio Power Automate](https://github.com/ninihen1/power-automate-mcp-skills) - Debug, build, and operate Power Automate flows via FlowStudio MCP with action-level inputs and outputs.
 - [HOTL Plugin](https://github.com/yimwoo/hotl-plugin) - Human-on-the-Loop AI coding workflow plugin.
 - [Jenkins CLI](https://github.com/avivsinai/jenkins-cli) - GitHub CLI-style interface for Jenkins controllers with jobs, pipelines, runs, logs, artifacts, credentials, and nodes.
@@ -136,6 +137,7 @@ Claude Code extends Anthropic's CLI with custom plugins. Official plugins: [anth
 - [claude-ops](https://github.com/Lifecycle-Innovations-Limited/claude-ops) - Business operating system for Claude Code — morning briefing, unified inbox (Slack/Telegram/WhatsApp/Gmail), autonomous PR merge pipeline, production incident dashboard, AWS cost tracking, and YOLO autonomous mode with 4 parallel C-suite agents. 14 slash commands, 9 agents.
 - [code-review](https://github.com/anthropics/claude-code/tree/main/plugins/code-review) - Automated PR code review using multiple specialized agents with confidence-based scoring to filter false positives.
 - [commit-commands](https://github.com/anthropics/claude-code/tree/main/plugins/commit-commands) - Git workflow automation for committing, pushing, and creating pull requests.
+- [Dodo Payments](https://github.com/dodopayments/dodo-agent-plugin) - Payments integration for checkouts, subscriptions, and billing with live API and documentation MCP servers with browser OAuth.
 - [feature-dev](https://github.com/anthropics/claude-code/tree/main/plugins/feature-dev) - Comprehensive feature development workflow with a structured 7-phase approach.
 - [immich-photo-manager](https://github.com/drolosoft/immich-photo-manager) - MCP server for intelligent photo management with Immich — search, geographic album curation, library cleanup, duplicate detection, and interactive HTML galleries.
 - [Lastest](https://github.com/las-team/lastest) - Self-hosted visual regression testing platform with AI-generated tests, MCP server integration, and collaborative diff review.
@@ -161,6 +163,7 @@ Plugins for OpenAI's OpenCode. See: [awesome-opencode-plugins](https://github.co
 _Contributions welcome - submit via PR_
 
 - [AI Plugin Scanner](https://github.com/hashgraph-online/ai-plugin-scanner) - Security and best-practices scanner for AI plugins.
+- [Dodo Payments](https://github.com/dodopayments/dodo-agent-plugin) - Payments integration for checkouts, subscriptions, and billing with live API and documentation MCP servers with browser OAuth.
 - [MCD Agent Toolkit](https://github.com/monte-carlo-data/mcd-agent-toolkit) - Official Monte Carlo toolkit for AI coding agents.
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry.
 

--- a/plugins.json
+++ b/plugins.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "name": "awesome-ai-plugins",
   "version": "1.0.0",
-  "last_updated": "2026-05-02",
-  "total": 91,
+  "last_updated": "2026-05-10",
+  "total": 94,
   "platforms": [
     "codex",
     "claude-code",
@@ -152,6 +152,15 @@
       "owner": "Rothschildiuk",
       "repo": "context-pack",
       "description": "Generate compact first-pass repository briefings for coding agents before deeper exploration",
+      "platform": "codex",
+      "source": "awesome-ai-plugins"
+    },
+    {
+      "name": "Dodo Payments",
+      "url": "https://github.com/dodopayments/dodo-agent-plugin",
+      "owner": "dodopayments",
+      "repo": "dodo-agent-plugin",
+      "description": "Payments integration for checkouts, subscriptions, and billing with live API and documentation MCP servers with browser OAuth",
       "platform": "codex",
       "source": "awesome-ai-plugins"
     },
@@ -426,6 +435,15 @@
       "source": "awesome-ai-plugins"
     },
     {
+      "name": "Dodo Payments",
+      "url": "https://github.com/dodopayments/dodo-agent-plugin",
+      "owner": "dodopayments",
+      "repo": "dodo-agent-plugin",
+      "description": "Payments integration for checkouts, subscriptions, and billing with live API and documentation MCP servers with browser OAuth",
+      "platform": "claude-code",
+      "source": "awesome-ai-plugins"
+    },
+    {
       "name": "feature-dev",
       "url": "https://github.com/anthropics/claude-code/tree/main/plugins/feature-dev",
       "owner": "anthropics",
@@ -521,6 +539,15 @@
       "owner": "hashgraph-online",
       "repo": "ai-plugin-scanner",
       "description": "Security and best-practices scanner for AI plugins",
+      "platform": "opencode",
+      "source": "awesome-ai-plugins"
+    },
+    {
+      "name": "Dodo Payments",
+      "url": "https://github.com/dodopayments/dodo-agent-plugin",
+      "owner": "dodopayments",
+      "repo": "dodo-agent-plugin",
+      "description": "Payments integration for checkouts, subscriptions, and billing with live API and documentation MCP servers with browser OAuth",
       "platform": "opencode",
       "source": "awesome-ai-plugins"
     },


### PR DESCRIPTION
Adds the official **Dodo Payments** plugin to three sections (it ships first-class manifests for all three runtimes from a single source of truth):

- **OpenAI Codex Plugins → Community Plugins** (alphabetized between *Context Pack* and *Flow Studio Power Automate*)
- **Claude Code Plugins** (alphabetized between *commit-commands* and *feature-dev*)
- **OpenCode Plugins → Community Plugins** (alphabetized between *AI Plugin Scanner* and *MCD Agent Toolkit*)

Plugin manifests:
- \`.codex-plugin/plugin.json\` — Codex CLI
- \`.claude-plugin/plugin.json\` — Claude Code (\`claude plugins marketplace add dodopayments/dodo-agent-plugin\`)
- \`.cursor-plugin/plugin.json\` — Cursor
- \`@dodopayments/opencode-plugin\` (npm) — OpenCode (auto-registers MCPs and skills via \`config\` hook)

License: MIT. Already merged into [hashgraph-online/awesome-codex-plugins #86](https://github.com/hashgraph-online/awesome-codex-plugins/pull/86).

Followed CONTRIBUTING.md: one-sentence description, alphabetical order within each section.