### PR TITLE
Add agenttrace

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
   "source": "awesome-ai-plugins",
-  "last_updated": "2026-05-02T13:11:20.929065+00:00",
+  "last_updated": "2026-05-10T05:08:04.771771+00:00",
   "plugins": [
     {
       "name": "Agent Message Queue",
@@ -18,6 +18,15 @@
       "owner": "boshu2",
       "repo": "agentops",
       "description": "DevOps layer for coding agents with flow, feedback, and memory",
+      "platform": "codex",
+      "source": "awesome-ai-plugins"
+    },
+    {
+      "name": "agenttrace",
+      "url": "https://github.com/luoyuctl/agenttrace",
+      "owner": "luoyuctl",
+      "repo": "agenttrace",
+      "description": "Local Codex plugin and TUI for inspecting AI coding agent session cost, latency, tool failures, and health",
       "platform": "codex",
       "source": "awesome-ai-plugins"
     },
@@ -238,20 +247,20 @@
       "source": "awesome-ai-plugins"
     },
     {
-      "name": "PapersFlow",
-      "url": "https://github.com/papersflow-ai/papersflow-codex-plugin",
-      "owner": "papersflow-ai",
-      "repo": "papersflow-codex-plugin",
-      "description": "Paper discovery, citation verification, graph exploration, and DeepScan analysis",
-      "platform": "codex",
-      "source": "awesome-ai-plugins"
-    },
-    {
       "name": "Paper Pilot",
       "url": "https://github.com/aytzey/paper-pilot",
       "owner": "aytzey",
       "repo": "paper-pilot",
       "description": "Academic research copilot that searches 6 databases, downloads real PDFs, extracts evidence, renders figures, and syncs to Zotero",
+      "platform": "codex",
+      "source": "awesome-ai-plugins"
+    },
+    {
+      "name": "PapersFlow",
+      "url": "https://github.com/papersflow-ai/papersflow-codex-plugin",
+      "owner": "papersflow-ai",
+      "repo": "papersflow-codex-plugin",
+      "description": "Paper discovery, citation verification, graph exploration, and DeepScan analysis",
       "platform": "codex",
       "source": "awesome-ai-plugins"
     },

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Third-party plugins built by the community.
 
 - [Agent Message Queue](https://github.com/avivsinai/agent-message-queue) - File-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations.
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory.
+- [agenttrace](https://github.com/luoyuctl/agenttrace) - Local Codex plugin and TUI for inspecting AI coding agent session cost, latency, tool failures, and health.
 - [Apple Productivity](https://github.com/matk0shub/apple-productivity-mcp) - Local Apple Calendar and Reminders for macOS.
 - [BikeScout](https://github.com/hifly81/bikescout) - Specialized MCP server for technical cycling providing terrain-aware routing, predictive mud-risk analysis, and UCI-standard climb categorization.
 - [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) - Manage Bitbucket repos, PRs, and pipelines.
@@ -109,8 +110,8 @@ Third-party plugins built by the community.
 - [OpenProject](https://github.com/varaprasadreddy9676/team-codex-plugins) - Team collaboration via OpenProject integration.
 - [OrgX](https://github.com/useorgx/orgx-codex-plugin) - MCP access and initiative-aware skills for organizational workflows.
 - [PANews Agent Toolkit](https://github.com/panewslab/skills) - Crypto and blockchain news discovery, authenticated creator publishing workflows, and page-to-Markdown reading.
-- [PapersFlow](https://github.com/papersflow-ai/papersflow-codex-plugin) - Paper discovery, citation verification, graph exploration, and DeepScan analysis.
 - [Paper Pilot](https://github.com/aytzey/paper-pilot) - Academic research copilot that searches 6 databases, downloads real PDFs, extracts evidence, renders figures, and syncs to Zotero.
+- [PapersFlow](https://github.com/papersflow-ai/papersflow-codex-plugin) - Paper discovery, citation verification, graph exploration, and DeepScan analysis.
 - [Project Autopilot](https://github.com/AlexMi64/codex-project-autopilot) - Turn an idea into a structured project workflow with planning, execution, verification, and handoff.
 - [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) - Route image-generation prompts to 30+ models — DALL-E, Stable Diffusion, Flux, Midjourney, and more — through a single MCP interface.
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry.

--- a/plugins.json
+++ b/plugins.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "name": "awesome-ai-plugins",
   "version": "1.0.0",
-  "last_updated": "2026-05-02",
-  "total": 91,
+  "last_updated": "2026-05-10",
+  "total": 92,
   "platforms": [
     "codex",
     "claude-code",
@@ -26,6 +26,15 @@
       "owner": "boshu2",
       "repo": "agentops",
       "description": "DevOps layer for coding agents with flow, feedback, and memory",
+      "platform": "codex",
+      "source": "awesome-ai-plugins"
+    },
+    {
+      "name": "agenttrace",
+      "url": "https://github.com/luoyuctl/agenttrace",
+      "owner": "luoyuctl",
+      "repo": "agenttrace",
+      "description": "Local Codex plugin and TUI for inspecting AI coding agent session cost, latency, tool failures, and health",
       "platform": "codex",
       "source": "awesome-ai-plugins"
     },
@@ -246,20 +255,20 @@
       "source": "awesome-ai-plugins"
     },
     {
-      "name": "PapersFlow",
-      "url": "https://github.com/papersflow-ai/papersflow-codex-plugin",
-      "owner": "papersflow-ai",
-      "repo": "papersflow-codex-plugin",
-      "description": "Paper discovery, citation verification, graph exploration, and DeepScan analysis",
-      "platform": "codex",
-      "source": "awesome-ai-plugins"
-    },
-    {
       "name": "Paper Pilot",
       "url": "https://github.com/aytzey/paper-pilot",
       "owner": "aytzey",
       "repo": "paper-pilot",
       "description": "Academic research copilot that searches 6 databases, downloads real PDFs, extracts evidence, renders figures, and syncs to Zotero",
+      "platform": "codex",
+      "source": "awesome-ai-plugins"
+    },
+    {
+      "name": "PapersFlow",
+      "url": "https://github.com/papersflow-ai/papersflow-codex-plugin",
+      "owner": "papersflow-ai",
+      "repo": "papersflow-codex-plugin",
+      "description": "Paper discovery, citation verification, graph exploration, and DeepScan analysis",
       "platform": "codex",
       "source": "awesome-ai-plugins"
     },


### PR DESCRIPTION
Adds agenttrace to the OpenAI Codex community plugins list. agenttrace ships a Codex plugin manifest and local TUI/reporting workflow for inspecting AI coding agent session cost, latency, tool failures, and health.\n\nValidation:\n- /opt/homebrew/bin/python3.11 scripts/check-alphabetical.py README.md\n- /opt/homebrew/bin/python3.11 scripts/generate_plugins_json.py\n- /opt/homebrew/bin/python3.11 -m json.tool plugins.json\n- /opt/homebrew/bin/python3.11 -m json.tool .agents/plugins/marketplace.json\n- git diff --check\n- pipx run codex-plugin-scanner lint .\n\nNote: pipx run codex-plugin-scanner verify . currently fails on the existing marketplace manifest schema because every entry is missing the same scanner-required metadata fields (for example source.path and policy), so I left that broader schema migration untouched.