### PR TITLE
Add Vibe plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Third-party plugins built by the community.
 - [TokRepo Search](https://github.com/henu-wang/tokrepo-codex-plugin) - Search and install AI assets from TokRepo with a bundled skill and MCP server for Codex.
 - [unslop](https://github.com/MohamedAbdallah-14/unslop) - Strip AI writing patterns from text — removes filler phrases, hedging language, and generic constructs to produce cleaner written content.
 - [Upwork Autopilot](https://github.com/klajdikkolaj/upwork-autopilot) - Controlled Upwork job search, qualification, and proposal submission sessions through a dedicated Chrome profile.
+- [Vibe](https://github.com/anubhavg-icpl/vibe) - Unified AI coding workflow library with Codex-ready skills, agents, commands, and modes for major coding-agent CLIs.
 - [VibePortrait](https://github.com/dadwadw233/VibePortrait) - Developer personality portrait generator — analyzes AI conversation history to produce MBTI type (16 color themes), capability radar, developer rating, 3-dimension famous match, and a persona skill that lets any AI "think like you".
 - [Yandex Direct](https://github.com/nebelov/yandex-direct-for-all) - GitHub-ready Codex plugin bundle for Yandex Direct, Wordstat, Metrika, and Roistat.
 - [Zotero Fulltext](https://github.com/statzhero/zotero-fulltext) - Search and read your Zotero library with citekey lookup and fulltext access.


### PR DESCRIPTION
## What changed

- Added Vibe to the OpenAI Codex Community Plugins section.

## Why

Vibe ships a `.codex-plugin/plugin.json` manifest and provides a Codex-ready AI coding workflow library with skills, agents, commands, and modes for major coding-agent CLIs.

## Validation

- Confirmed the repository includes `.codex-plugin/plugin.json`.
- Confirmed the entry follows `CONTRIBUTING.md` format and is alphabetized before VibePortrait.
- `git diff --check`

Note: `pipx run codex-plugin-scanner lint /Users/anubhavg/Desktop/vibe` is blocked in my local environment by a broken Homebrew Python 3.14 interpreter, before scanner execution starts.
