### PR TITLE
feat: add Obsidian Vault MCP to community plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Third-party plugins built by the community.
 - [KiCad Happy](https://github.com/aklofas/kicad-happy) - KiCad EDA skills for schematic analysis, PCB layout review, component sourcing, BOM management, and manufacturing preparation.
 - [Langfuse Observability](https://github.com/avivsinai/langfuse-mcp) - Query traces, debug exceptions, analyze sessions.
 - [Launch Fast](https://github.com/BlockchainHB/launchfast_codex_plugin) - Official Launch Fast plugin adapter for rapid SaaS deployment.
+- [Obsidian Vault MCP](https://github.com/luffysolution-svg/obsidian-vault-mcp) - Maintain a local Obsidian vault as a persistent linked wiki with 57 MCP tools for file I/O, wikilinks, Zotero import, MinerU PDF parsing, Canvas/Bases creation, and batch editing.
 - [OC ChatGPT Multi Auth](https://github.com/ndycode/oc-chatgpt-multi-auth) - Codex setup skill and OpenCode plugin for ChatGPT Plus/Pro OAuth, GPT-5/Codex presets, and multi-account failover.
 - [OpenProject](https://github.com/varaprasadreddy9676/team-codex-plugins) - Team collaboration via OpenProject integration.
 - [OrgX](https://github.com/useorgx/orgx-codex-plugin) - MCP access and initiative-aware skills for organizational workflows.


### PR DESCRIPTION
## Summary

Add [Obsidian Vault MCP](https://github.com/luffysolution-svg/obsidian-vault-mcp) to the Community Plugins section (alphabetical order, between Launch Fast and OC ChatGPT Multi Auth).

**What it does:** Maintains a local Obsidian vault as a persistent linked wiki via 57 MCP tools — file I/O, wikilinks, Zotero import, MinerU PDF parsing, Canvas/Bases creation, and batch editing.

**Clients supported:** Claude Code, Codex, OpenCode, and any stdio MCP client.

**Verification:**
- Active development with recent releases (v1.0.4 released 2026-05-11)
- 46 unit tests passing on Ubuntu and Windows CI
- MIT license