### PR TITLE
Add Sensei plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Third-party plugins built by the community.
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry.
 - [Remotion Plugin](https://github.com/tim-osterhus/codex-remotion-plugin) - Build parameterized Remotion videos in Codex.
 - [ru-text](https://github.com/talkstream/ru-text) - Russian text quality — ~1,040 rules for typography, info-style, editorial, UX writing, and business correspondence.
+- [Sensei](https://github.com/onehorizonai/sensei) - Senior engineering coach for code review, debugging, planning, refactoring, and test-quality practice.
 - [sitemd](https://github.com/sitemd-cc/sitemd) - Build websites from Markdown via MCP — 22 tools for creating pages, generating content, validating, running SEO audits, configuring settings, and deploying static sites to Cloudflare Pages.
 - [SocratiCode](https://github.com/giancarloerra/SocratiCode) - Codebase intelligence MCP server with semantic search, dependency graph analysis, and context artifact exploration.
 - [Synta MCP](https://github.com/Synta-ai/n8n-mcp-codex-plugin-synta) - Build, edit, validate, and self-heal n8n workflows with Synta MCP tools and Codex-ready workflow guidance.


### PR DESCRIPTION
## Summary

- Add Sensei to the OpenAI Codex Community Plugins list.
- Link to the public Sensei plugin repository.

## Validation

- `git diff --check` in `hashgraph-online/awesome-ai-plugins`: pass.
- `gh repo view onehorizonai/sensei`: link resolves to a public repository.
- `pipx run codex-plugin-scanner lint .` in `onehorizonai/sensei`: pass, `policy_pass=True`, score 86.
- `pipx run codex-plugin-scanner verify .` in `onehorizonai/sensei`: fails on existing marketplace metadata warnings: `plugin[0] missing "source.path"` and `plugin[0] missing policy object`; manifest, interface metadata, assets, MCP config, and skills checks pass.
