### PR TITLE
Add Allscreenshots plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 
 - [Agent Message Queue](https://github.com/avivsinai/agent-message-queue) - File-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations.
 - [Agent Vision](https://github.com/zfifteen/agent-vision) - macOS-only local camera plugin for explicit snapshots, streaming controls, and file-backed image input.
+- [Allscreenshots](https://github.com/allscreenshots/allscreenshots-plugin) - Capture website screenshots from Codex with viewport sizing, full-page capture, dark mode, and ad or cookie banner blocking.
 - [Apple Productivity](https://github.com/matk0shub/apple-productivity-mcp) - Local Apple Calendar and Reminders tooling for macOS with Codex plugin adapters.
 - [AxonFlow](https://github.com/getaxonflow/axonflow-codex-plugin) - Runtime governance for Codex with policy enforcement on terminal commands, advisory checks for non-terminal tools via skills, PII/secret detection, and compliance-grade audit trails. Self-hosted via Docker.
 - [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) - Manage Bitbucket repos, PRs, branches, issues, webhooks, and pipelines for Data Center and Cloud.


### PR DESCRIPTION
## Description

Adds Allscreenshots, a Codex plugin for capturing website screenshots through the Allscreenshots API.

## Repository

https://github.com/allscreenshots/allscreenshots-plugin

## Category

Community Plugins / Tools & Integrations

## Verification

- Added the entry to `README.md` in alphabetical order.
- Ran `python3 scripts/check-alphabetical.py README.md` successfully.
- Confirmed the Allscreenshots repo includes `.codex-plugin/plugin.json`.
- Ran `pipx run codex-plugin-scanner lint .` in the Allscreenshots plugin repo: completed with `policy_pass=True`.
- Ran `pipx run codex-plugin-scanner verify .` in the Allscreenshots plugin repo: MCP stdio initialized and listed `take_screenshot` and `get_api_info`, but the command exited nonzero because of an existing marketplace metadata warning: `plugin[0] missing "source.path"`.
