### PR TITLE
Add Spellbook Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Secret Guard](./plugins/mturac/secret-guard) - Pre-commit secret scanner using pattern and entropy detection.
 - [Session Orchestrator](https://github.com/Kanevry/session-orchestrator) - Session orchestration for Claude Code, Codex, and Cursor IDE — structured planning, wave-based execution, VCS integration (GitLab + GitHub), quality gates, and clean session close-out with issue tracking.
 - [Spec-Driven Development](https://github.com/Habib0x0/spec-driven-plugin) - Three-phase Requirements → Design → Tasks workflow for Claude Code and Codex — EARS notation acceptance criteria, autonomous execution loop, cross-spec dependencies, and post-implementation acceptance testing.
+- [Spellbook Skills](https://github.com/yyykf/spellbook-skills) - Practical Claude Code and Codex skills for worktrees, PR/MR automation, review cleanup, YApi lookup, and Java DDD guidance.
 - [Standup Generator](./plugins/mturac/standup-gen) - Daily standup notes from git activity across repos.
 - [Stark](https://github.com/f0d010c/stark) - UI/UX design plugin for AI coding agents with product-flow routing, platform-native interface guidance, asset planning, and shipped-reference analysis before code.
 - [tailtest](https://github.com/avansaber/tailtest-codex) - Hook-powered test generation -- detects files changed during an agent turn and instructs Codex to write and run tests automatically. Zero config, 8 languages.


### PR DESCRIPTION
## Summary

- Add Spellbook Skills to the Development & Workflow section.

## Verification

- Confirmed the repository is public and includes `.codex-plugin/plugin.json`.
- Confirmed a local Codex plugin cache exists for `spellbook-skills` version `0.3.0`.
- Ran `python3 scripts/check-alphabetical.py README.md`.
- Ran `uvx codex-plugin-scanner lint .` against `yyykf/spellbook-skills`; result: `policy_pass=True`, effective score `83`.
