### PR TITLE
Add Mantis to Tools & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [KiCad Happy](https://github.com/aklofas/kicad-happy) - KiCad EDA skills for schematic analysis, PCB layout review, component sourcing, BOM management, and manufacturing preparation.
 - [Langfuse Observability](https://github.com/avivsinai/langfuse-mcp) - Query traces, debug exceptions, analyze sessions, and manage prompts via MCP tools.
 - [Launch Fast](https://github.com/BlockchainHB/launchfast_codex_plugin) - Official Launch Fast plugin adapter for rapid SaaS deployment.
+- [Mantis](https://github.com/deonmenezes/mantishack) - Autonomous bug bounty hunter for authorized engagements — 7-phase FSM (RECON → AUTH → HUNT → CHAIN → VERIFY → GRADE → REPORT), parallel hunter sub-agents, cryptographic scope enforcement, and BLAKE3/Ed25519 Merkle event logs.
 - [Mobazha](https://github.com/mobazha/mobazha-skills) - Decentralized e-commerce skills — deploy self-hosted stores, import products from Shopify/Amazon, configure custom domains and Telegram bots, set up Tor privacy, and manage your store via MCP.
 - [MorningAI](https://github.com/octo-patch/MorningAI) - AI news tracking skill that monitors 80+ entities across 6 sources (Reddit, HN, GitHub, Hugging Face, arXiv, X) and generates scored daily reports with infographics and message digests.
 - [Nullcost](https://github.com/johnvouros/nullcost-plugin) - Catalog-backed free-tier, free-trial, and cheap developer-tool recommendations for Codex through bundled skills and MCP tools.

--- a/plugins.json
+++ b/plugins.json
@@ -3,7 +3,7 @@
   "name": "awesome-ai-plugins",
   "version": "1.0.0",
   "last_updated": "2026-05-23",
-  "total": 83,
+  "total": 84,
   "platforms": [
     "codex"
   ],
@@ -918,6 +918,21 @@
       "platform": "codex",
       "ecosystems": [
         "codex"
+      ]
+    },
+    {
+      "name": "Mantis",
+      "url": "https://github.com/deonmenezes/mantishack",
+      "owner": "deonmenezes",
+      "repo": "mantishack",
+      "description": "Autonomous bug bounty hunter for authorized engagements — 7-phase FSM (RECON → AUTH → HUNT → CHAIN → VERIFY → GRADE → REPORT), parallel hunter sub-agents, cryptographic scope enforcement, and BLAKE3/Ed25519 Merkle event logs.",
+      "category": "Tools & Integrations",
+      "source": "awesome-ai-plugins",
+      "install_url": "https://raw.githubusercontent.com/deonmenezes/mantishack/HEAD/.codex-plugin/plugin.json",
+      "platform": "codex",
+      "ecosystems": [
+        "codex",
+        "claude-code"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Add **Mantis** (https://github.com/deonmenezes/mantishack) entry under **Tools & Integrations**
- Alphabetical placement between Launch Fast and Mobazha
- Matching `plugins.json` record with `install_url` pointing to the canonical `.codex-plugin/plugin.json`
- Bump `plugins.json` total: 83 → 84

## What is Mantis?
Mantis is an autonomous bug bounty hunter for authorized engagements only. It runs a 7-phase FSM (RECON → AUTH → HUNT → CHAIN → VERIFY → GRADE → REPORT) with parallel hunter sub-agents, cryptographic scope enforcement, and BLAKE3/Ed25519 Merkle event logs. Works with Claude Code, Codex CLI, and any MCP-capable host via `npx -y -p mantishack mantis-mcp`.

- npm: https://www.npmjs.com/package/mantishack
- Site: https://mantishack.com
- License: Apache-2.0 OR MIT

## Test plan
- [x] `plugins.json` parses as valid JSON (total bumped, alphabetical position preserved)
- [x] README entry follows the existing format
- [x] Install URL resolves (after the matching PR on deonmenezes/mantishack lands: https://github.com/deonmenezes/mantishack/pull/13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)