### PR TITLE
Add Runtype Skills plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Praxis](https://github.com/ouonet/praxis) - Intent-driven workflow skills for coding agents: describe what done looks like, not the steps. Triage-first design keeps token costs low across design, TDD, debug, review, and release.
 - [Project Autopilot](https://github.com/AlexMi64/codex-project-autopilot) - Turn an idea into a structured project workflow with planning, execution, verification, and handoff.
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry, plan, find, summon, and recover sessions.
+- [Runtype Skills](https://github.com/runtypelabs/skills) - Build, deploy, and operate AI agents, flows, tools, and surfaces on Runtype's managed edge runtime from Claude Code and Codex CLI.
 - [Sealos](https://github.com/labring/sealos-skills) - Deploy apps to Sealos Cloud from Codex with readiness checks, Dockerfile generation, Compose conversion, image builds, and rollout updates.
 - [Secret Guard](./plugins/mturac/secret-guard) - Pre-commit secret scanner using pattern and entropy detection.
 - [Session Orchestrator](https://github.com/Kanevry/session-orchestrator) - Session orchestration for Claude Code, Codex, and Cursor IDE — structured planning, wave-based execution, VCS integration (GitLab + GitHub), quality gates, and clean session close-out with issue tracking.


### PR DESCRIPTION
## Summary

- Adds [Runtype Skills](https://github.com/runtypelabs/skills) to the **Development & Workflow** section
- Runtype Skills is a Claude Code / Codex CLI plugin for building, deploying, and operating AI agents, flows, tools, and surfaces on Runtype's managed edge runtime
- MIT-licensed, published by [runtypelabs](https://github.com/runtypelabs)

## Plugin details

| Field | Value |
|-------|-------|
| **Repository** | https://github.com/runtypelabs/skills |
| **Plugin manifest** | [`.codex-plugin/plugin.json`](https://github.com/runtypelabs/skills/blob/main/.codex-plugin/plugin.json) |
| **Install URL** | `https://raw.githubusercontent.com/runtypelabs/skills/HEAD/.codex-plugin/plugin.json` |
| **License** | MIT |
| **Platforms** | Claude Code, Codex CLI |

## Verification

- Plugin manifest exists at `.codex-plugin/plugin.json` with valid structure (name, version, description, publisher, skills path)
- Repository is public with recent commits and an MIT license
- Entry placed in alphabetical order within the Development & Workflow section
- Alphabetical sort check passes locally (`python3 scripts/check-alphabetical.py`)