### PR TITLE
Update Agentgram listing

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -757,7 +757,7 @@
     {
       "name": "Agentgram",
       "displayName": "Agentgram",
-      "description": "Send explicit Telegram messages from Codex and local AI agents through a Telegram bot token and chat id.",
+      "description": "Send Telegram messages, files, and forwarded inbox imports from Codex and local AI agents through a Telegram bot token and chat id.",
       "category": "Tools & Integrations",
       "source": "awesome-ai-plugins",
       "platform": "codex",

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 
 - [Agent Message Queue](https://github.com/avivsinai/agent-message-queue) - File-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations.
 - [Agent Vision](https://github.com/zfifteen/agent-vision) - macOS-only local camera plugin for explicit snapshots, streaming controls, and file-backed image input.
-- [Agentgram](https://github.com/jerryfane/agentgram) - Send explicit Telegram messages from Codex and local AI agents through a Telegram bot token and chat id.
+- [Agentgram](https://github.com/jerryfane/agentgram) - Send Telegram messages, files, and forwarded inbox imports from Codex and local AI agents through a Telegram bot token and chat id.
 - [Apple Productivity](https://github.com/matk0shub/apple-productivity-mcp) - Local Apple Calendar and Reminders tooling for macOS with Codex plugin adapters.
 - [AxonFlow](https://github.com/getaxonflow/axonflow-codex-plugin) - Runtime governance for Codex with policy enforcement on terminal commands, advisory checks for non-terminal tools via skills, PII/secret detection, and compliance-grade audit trails. Self-hosted via Docker.
 - [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) - Manage Bitbucket repos, PRs, branches, issues, webhooks, and pipelines for Data Center and Cloud.

--- a/plugins.json
+++ b/plugins.json
@@ -714,7 +714,7 @@
       "url": "https://github.com/jerryfane/agentgram",
       "owner": "jerryfane",
       "repo": "agentgram",
-      "description": "Send explicit Telegram messages from Codex and local AI agents through a Telegram bot token and chat id.",
+      "description": "Send Telegram messages, files, and forwarded inbox imports from Codex and local AI agents through a Telegram bot token and chat id.",
       "category": "Tools & Integrations",
       "source": "awesome-ai-plugins",
       "install_url": "https://raw.githubusercontent.com/jerryfane/agentgram/HEAD/.codex-plugin/plugin.json",


### PR DESCRIPTION
## Summary

Refresh the Agentgram listing text for the latest upstream release.

## What changed

- Mention Telegram file sending and forwarded inbox imports in the README entry.
- Keep `plugins.json` and `.agents/plugins/marketplace.json` descriptions in sync.
- Leave the install URL pointing at `jerryfane/agentgram/HEAD/.codex-plugin/plugin.json`, which now resolves to Agentgram `v0.2.2`.

Upstream release: https://github.com/jerryfane/agentgram/releases/tag/v0.2.2

## Validation

- `python3 scripts/check-alphabetical.py README.md`
- `python3 -m json.tool plugins.json`
- `python3 -m json.tool .agents/plugins/marketplace.json`
- `git diff --check`