### PR TITLE
Add Vibe Browser to Tools & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [TokRepo Search](https://github.com/henu-wang/tokrepo-codex-plugin) - Search and install AI assets from TokRepo with a bundled skill and MCP server for Codex.
 - [unslop](https://github.com/MohamedAbdallah-14/unslop) - Strip AI writing patterns from text output — removes filler phrases, hedging language, and generic constructs to produce cleaner written content. Install: `npm install -g unslop`.
 - [Upwork Autopilot](https://github.com/klajdikkolaj/upwork-autopilot) - Controlled Upwork job search, qualification, and proposal submission sessions through a dedicated Chrome profile.
+- [Vibe Browser](https://github.com/VibeTechnologies/vibe-browser-codex-plugin) - Drive your real, already-logged-in Chrome from Codex through the Vibe extension and relay with navigate, accessibility snapshot, click, type, and screenshot tools.
 - [VidSeeds.ai](https://github.com/CarrotGamesStudios/vidseeds-mcp) - Hosted MCP connector for pre-upload video SEO, metadata optimization, AI thumbnails, and multi-platform publishing with workflow skills for Codex agents.
 - [X Twitter Scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data, monitored workflows, HMAC webhooks, and MCP access through the Xquik REST API with confirmation-gated write guidance.
 - [Yandex Direct](https://github.com/nebelov/yandex-direct-for-all) - GitHub-ready Codex plugin bundle for Yandex Direct, Wordstat, Metrika, and Roistat.


### PR DESCRIPTION
## Extension

**[Vibe Browser](https://github.com/VibeTechnologies/vibe-browser-codex-plugin)** — a Codex plugin that wraps [`@vibebrowser/mcp`](https://github.com/VibeTechnologies/vibe-mcp) so Codex can drive the user's **real, already-logged-in Chrome** through the Vibe browser extension and relay (navigate, accessibility snapshot, click, fill, type, screenshot, tabs). Unlike headless drivers it reuses the real profile and sessions, and multiple agents can share one browser via the relay.

- Repo: https://github.com/VibeTechnologies/vibe-browser-codex-plugin
- Category: **Community Plugins → Tools & Integrations** (placed alphabetically between *Upwork Autopilot* and *VidSeeds.ai*)

## Scanner evidence (mandatory requirements)

The plugin repo runs the HOL AI Plugin Scanner in GitHub Actions (`hashgraph-online/ai-plugin-scanner-action`, SHA-pinned, `fail_on_severity: high`):

- **Score: 97 / 142** (≥ 80 ✅)
- **policy_pass: true** — no critical or high severity findings ✅
- **Scanner runs in CI**: https://github.com/VibeTechnologies/vibe-browser-codex-plugin/actions ✅
- Repo includes `LICENSE` (Apache-2.0), `SECURITY.md`, Dependabot, scanner badge, and a `vibe-browser` skill.

## Verification

The plugin launches the published, working `@vibebrowser/mcp` server (`npx -y @vibebrowser/mcp@latest start`) via `.mcp.json`; the upstream package is published on npm and used today by Codex/OpenCode.