### PR TITLE
Add Superloopy

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Staff Engineer Mode](https://github.com/sirmarkz/staff-engineer-mode) - Routes engineering design, delivery, reliability, security, operations, and maintenance prompts to focused staff-level specialist guidance for AI coding agents.
 - [Standup Generator](./plugins/mturac/standup-gen) - Daily standup notes from git activity across repos.
 - [Stark](https://github.com/f0d010c/stark) - UI/UX design plugin for AI coding agents with product-flow routing, platform-native interface guidance, asset planning, and shipped-reference analysis before code.
+- [Superloopy](https://github.com/beefiker/superloopy) - Evidence-gated Codex loop harness with specialist skills, including near-pixel authorized website cloning backed by screenshots, assets, build output, and visual QA.
 - [tailtest](https://github.com/avansaber/tailtest-codex) - Hook-powered test generation -- detects files changed during an agent turn and instructs Codex to write and run tests automatically. Zero config, 8 languages.
 - [Tandem Workflow Architect](https://github.com/frumu-ai/tandem-codex-plugin) - Plan Tandem workflows in Codex, then validate, preview, and run them through the governed Tandem engine.
 - [Tartiner Labs](https://github.com/tartinerlabs/skills) - Agent skills for git workflows, GitHub automation, security audits, code refactoring, and project tooling.


### PR DESCRIPTION
## Summary
- Add Superloopy to the Development & Workflow section.
- Position it as an evidence-gated Codex loop harness with specialist skills, including the authorized near-pixel website clone workflow.

## Verification
- Public plugin repo: https://github.com/beefiker/superloopy
- HOL scanner CI on plugin repo main: https://github.com/beefiker/superloopy/actions/runs/28366716132
- `plugin-scanner scan . --format text` in the plugin repo: Final Score 93/100 (A), critical:0, high:0, medium:0
- `plugin-scanner lint . --format text`: policy_pass=True, effective_score=93
- `plugin-scanner verify . --format text`: PASS
- `python3 scripts/check-alphabetical.py`
- `git diff --check`
