### PR TITLE
Add falsegreen-skill to Community Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Env Lint](./plugins/mturac/env-lint) - `.env` vs `.env.example` key parity — never prints values.
 - [Epic Harness](https://github.com/epicsagas/epic-harness) - Auto-trigger quality skills + self-evolving agent harness — orbit (spec-to-ship), evolve (skill mutation), team (multi-agent), TDD, check, ship, simplify, debug, perf, secure.
 - [Espresso](https://github.com/mirkobozzetto/espresso) - Full token-saving stack in one plugin - output compression, global rules, RTK hook, Caveman ultra, GitNexus config. Detects existing setup, installs only what's missing. Works on Claude Code and Codex.
+- [falsegreen-skill](https://github.com/vinicq/falsegreen-skill) - Detects false-positive tests that pass even when the code breaks, using the J1-J6 judgment framework across Python, TypeScript, JavaScript, and Robot Framework.
 - [Flaky Detector](./plugins/mturac/flaky-detector) - Run a test command N times, report per-test flakiness %.
 - [Frappe Agent](https://github.com/Dkm0315/frappe-agent) - Frappe and ERPNext coding, customization, bench, and review intelligence for Codex.
 - [GCF Proxy](https://github.com/blackwell-systems/gcf-codex-plugin) - Save 71% on MCP tool call tokens by wrapping any server with GCF encoding, with session stats hook and setup skill.


### PR DESCRIPTION
Adds one entry to **Community Plugins -> Development & Workflow** for [falsegreen-skill](https://github.com/vinicq/falsegreen-skill).

It is a test-quality skill for coding agents (Claude Code, Codex, Gemini) that detects false-positive tests: tests that keep passing green even when the code under test is broken. It applies a J1-J6 judgment framework (does the assertion run, does the value come from an independent oracle, is the real unit tested, etc.) across Python, TypeScript, JavaScript, and Robot Framework.

- Repo: https://github.com/vinicq/falsegreen-skill
- npm: https://www.npmjs.com/package/falsegreen-skill (currently 0.6.0)
- Ships `.claude-plugin/`, `.codex-plugin/`, and `gemini-extension.json`; listed once here as a skill to avoid duplicate entries.

Single additive line, inserted alphabetically. One-sentence description per CONTRIBUTING.md.

## Scanner CI

The HOL Plugin Scanner now runs in CI on the source repo via a dedicated workflow (`.github/workflows/plugin-scanner.yml`), on every push and pull request, failing on any high/critical finding.

- Passing run: https://github.com/vinicq/falsegreen-skill/actions/runs/28595159046
- Result: **96/100 (grade A), 0 critical, 0 high, 0 medium, 0 low**
- Workflow: https://github.com/vinicq/falsegreen-skill/blob/master/.github/workflows/plugin-scanner.yml

Scanner actions are SHA-pinned to keep the Operational score clean.
