### PR TITLE
feat: automate plugin claim notice on PR merge

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
   "source": "awesome-ai-plugins",
-  "last_updated": "2026-07-04T12:02:47.503053+00:00",
+  "last_updated": "2026-07-04T14:37:54.824493+00:00",
   "plugins": [
     {
       "name": "Registry Broker",
@@ -245,21 +245,6 @@
       "install_url": "https://raw.githubusercontent.com/armoriq/armorCodex/HEAD/plugins/armorcodex/.codex-plugin/plugin.json"
     },
     {
-      "name": "BGS Modding Superpowers",
-      "displayName": "BGS Modding Superpowers",
-      "description": "Agentic Bethesda Game Studio modpack curation toolkit with MCP-driven xEdit conflict audit, MO2 control plane, BA2/BSA and Papyrus tooling, and skills for setup, dev-log, and release-changelog workflows.",
-      "category": "Development & Workflow",
-      "source": "awesome-ai-plugins",
-      "platform": "codex",
-      "ecosystems": [
-        "codex"
-      ],
-      "owner": "BB-84C",
-      "repo": "bgs-modding-superpowers",
-      "url": "https://github.com/BB-84C/bgs-modding-superpowers",
-      "install_url": "https://raw.githubusercontent.com/BB-84C/bgs-modding-superpowers/HEAD/.codex-plugin/plugin.json"
-    },
-    {
       "name": "BABOK Analyst",
       "displayName": "BABOK Analyst",
       "description": "BABOK v3 business analysis agent with 16 MCP tools, a 9-stage pipeline, and human-in-the-loop approval gates.",
@@ -273,6 +258,21 @@
       "repo": "BABOK_ANALYST",
       "url": "https://github.com/GSkuza/BABOK_ANALYST",
       "install_url": "https://raw.githubusercontent.com/GSkuza/BABOK_ANALYST/HEAD/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "BGS Modding Superpowers",
+      "displayName": "BGS Modding Superpowers",
+      "description": "Agentic Bethesda Game Studio modpack curation toolkit with MCP-driven xEdit conflict audit, MO2 control plane, BA2/BSA and Papyrus tooling, and skills for setup, dev-log, and release-changelog workflows.",
+      "category": "Development & Workflow",
+      "source": "awesome-ai-plugins",
+      "platform": "codex",
+      "ecosystems": [
+        "codex"
+      ],
+      "owner": "BB-84C",
+      "repo": "bgs-modding-superpowers",
+      "url": "https://github.com/BB-84C/bgs-modding-superpowers",
+      "install_url": "https://raw.githubusercontent.com/BB-84C/bgs-modding-superpowers/HEAD/.codex-plugin/plugin.json"
     },
     {
       "name": "Boss",
@@ -1115,21 +1115,6 @@
       "install_url": "https://raw.githubusercontent.com/villagesql/villagesql-skills/HEAD/.codex-plugin/plugin.json"
     },
     {
-      "name": "Wingman",
-      "displayName": "Wingman",
-      "description": "Cross-platform AI coding-agent plugin for repo-local project memory, data-contract checks, and project-map discovery before agents edit code.",
-      "category": "Development & Workflow",
-      "source": "awesome-ai-plugins",
-      "platform": "codex",
-      "ecosystems": [
-        "codex"
-      ],
-      "owner": "lsshym",
-      "repo": "wingman.ai",
-      "url": "https://github.com/lsshym/wingman.ai",
-      "install_url": "https://raw.githubusercontent.com/lsshym/wingman.ai/HEAD/.codex-plugin/plugin.json"
-    },
-    {
       "name": "Waggle",
       "displayName": "Waggle",
       "description": "Persistent graph-backed conversational memory for Codex that recalls project decisions, constraints, preferences, and outcomes across sessions.",
@@ -1143,6 +1128,21 @@
       "repo": "Waggle-mcp",
       "url": "https://github.com/Abhigyan-Shekhar/Waggle-mcp",
       "install_url": "https://raw.githubusercontent.com/Abhigyan-Shekhar/Waggle-mcp/HEAD/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "Wingman",
+      "displayName": "Wingman",
+      "description": "Cross-platform AI coding-agent plugin for repo-local project memory, data-contract checks, and project-map discovery before agents edit code.",
+      "category": "Development & Workflow",
+      "source": "awesome-ai-plugins",
+      "platform": "codex",
+      "ecosystems": [
+        "codex"
+      ],
+      "owner": "lsshym",
+      "repo": "wingman.ai",
+      "url": "https://github.com/lsshym/wingman.ai",
+      "install_url": "https://raw.githubusercontent.com/lsshym/wingman.ai/HEAD/.codex-plugin/plugin.json"
     },
     {
       "name": "Workflow Kit",
@@ -1475,21 +1475,6 @@
       "install_url": "https://raw.githubusercontent.com/douglasmonsky/codex-usage-tracker/HEAD/.codex-plugin/plugin.json"
     },
     {
-      "name": "Context Pack",
-      "displayName": "Context Pack",
-      "description": "Generate compact first-pass repository briefings for coding agents before deeper exploration.",
-      "category": "Tools & Integrations",
-      "source": "awesome-ai-plugins",
-      "platform": "codex",
-      "ecosystems": [
-        "codex"
-      ],
-      "owner": "Rothschildiuk",
-      "repo": "context-pack",
-      "url": "https://github.com/Rothschildiuk/context-pack",
-      "install_url": "https://raw.githubusercontent.com/Rothschildiuk/context-pack/HEAD/.codex-plugin/plugin.json"
-    },
-    {
       "name": "CONTAM Tools",
       "displayName": "CONTAM Tools",
       "description": "Runs and inspects CONTAM airflow projects through a local MCP server with project guards, diagnostics, simulation helpers, and bridge workflows.",
@@ -1503,6 +1488,21 @@
       "repo": "CONTAM_plugin",
       "url": "https://github.com/summer521521/CONTAM_plugin",
       "install_url": "https://raw.githubusercontent.com/summer521521/CONTAM_plugin/HEAD/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "Context Pack",
+      "displayName": "Context Pack",
+      "description": "Generate compact first-pass repository briefings for coding agents before deeper exploration.",
+      "category": "Tools & Integrations",
+      "source": "awesome-ai-plugins",
+      "platform": "codex",
+      "ecosystems": [
+        "codex"
+      ],
+      "owner": "Rothschildiuk",
+      "repo": "context-pack",
+      "url": "https://github.com/Rothschildiuk/context-pack",
+      "install_url": "https://raw.githubusercontent.com/Rothschildiuk/context-pack/HEAD/.codex-plugin/plugin.json"
     },
     {
       "name": "Data Product Builder for dbt",
@@ -1895,21 +1895,6 @@
       "install_url": "https://raw.githubusercontent.com/jbaehova/pdf-monster/HEAD/.codex-plugin/plugin.json"
     },
     {
-      "name": "Pronounce",
-      "displayName": "Pronounce",
-      "description": "Pronounce developer jargon out loud: an MCP server (lookup/search) and skill backed by a 1,721-entry sourced dictionary with IPA, audio, and cited pronunciations for kubectl, nginx, YAML, JWT, and more.",
-      "category": "Tools & Integrations",
-      "source": "awesome-ai-plugins",
-      "platform": "codex",
-      "ecosystems": [
-        "codex"
-      ],
-      "owner": "anzy-renlab-ai",
-      "repo": "pronounce",
-      "url": "https://github.com/anzy-renlab-ai/pronounce",
-      "install_url": "https://raw.githubusercontent.com/anzy-renlab-ai/pronounce/HEAD/.codex-plugin/plugin.json"
-    },
-    {
       "name": "prompt-to-asset",
       "displayName": "prompt-to-asset",
       "description": "Route image-generation prompts to 30+ models (DALL-E, Stable Diffusion, Flux, Midjourney, and more) through a single MCP interface. Install: `npm install -g prompt-to-asset`.",
@@ -1923,6 +1908,21 @@
       "repo": "prompt-to-asset",
       "url": "https://github.com/MohamedAbdallah-14/prompt-to-asset",
       "install_url": "https://raw.githubusercontent.com/MohamedAbdallah-14/prompt-to-asset/HEAD/plugins/prompt-to-asset/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "Pronounce",
+      "displayName": "Pronounce",
+      "description": "Pronounce developer jargon out loud: an MCP server (lookup/search) and skill backed by a 1,721-entry sourced dictionary with IPA, audio, and cited pronunciations for kubectl, nginx, YAML, JWT, and more.",
+      "category": "Tools & Integrations",
+      "source": "awesome-ai-plugins",
+      "platform": "codex",
+      "ecosystems": [
+        "codex"
+      ],
+      "owner": "anzy-renlab-ai",
+      "repo": "pronounce",
+      "url": "https://github.com/anzy-renlab-ai/pronounce",
+      "install_url": "https://raw.githubusercontent.com/anzy-renlab-ai/pronounce/HEAD/.codex-plugin/plugin.json"
     },
     {
       "name": "Remotion Plugin",

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
   "source": "awesome-ai-plugins",
-  "last_updated": "2026-07-04T14:37:54.824493+00:00",
+  "last_updated": "2026-07-04T15:09:58.975463+00:00",
   "plugins": [
     {
       "name": "Registry Broker",

--- a/.github/workflows/claim-notice.yml
+++ b/.github/workflows/claim-notice.yml
@@ -1,0 +1,33 @@
+name: Plugin Claim Notice
+
+on:
+  pull_request:
+    types:
+      - closed
+    paths:
+      - "README.md"
+      - "plugins/**"
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  post-claim-notice:
+    # Only run on merged PRs
+    if: github.event.pull_request.merged == true
+    name: Post claim instructions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Post claim notice
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          REGISTRY_API: https://hol.org/registry/api/v1
+        run: python3 scripts/post-claim-notice.py

--- a/plugins.json
+++ b/plugins.json
@@ -235,20 +235,6 @@
       ]
     },
     {
-      "name": "BGS Modding Superpowers",
-      "url": "https://github.com/BB-84C/bgs-modding-superpowers",
-      "owner": "BB-84C",
-      "repo": "bgs-modding-superpowers",
-      "description": "Agentic Bethesda Game Studio modpack curation toolkit with MCP-driven xEdit conflict audit, MO2 control plane, BA2/BSA and Papyrus tooling, and skills for setup, dev-log, and release-changelog workflows.",
-      "category": "Development & Workflow",
-      "source": "awesome-ai-plugins",
-      "install_url": "https://raw.githubusercontent.com/BB-84C/bgs-modding-superpowers/HEAD/.codex-plugin/plugin.json",
-      "platform": "codex",
-      "ecosystems": [
-        "codex"
-      ]
-    },
-    {
       "name": "BABOK Analyst",
       "url": "https://github.com/GSkuza/BABOK_ANALYST",
       "owner": "GSkuza",
@@ -257,6 +243,20 @@
       "category": "Development & Workflow",
       "source": "awesome-ai-plugins",
       "install_url": "https://raw.githubusercontent.com/GSkuza/BABOK_ANALYST/HEAD/.codex-plugin/plugin.json",
+      "platform": "codex",
+      "ecosystems": [
+        "codex"
+      ]
+    },
+    {
+      "name": "BGS Modding Superpowers",
+      "url": "https://github.com/BB-84C/bgs-modding-superpowers",
+      "owner": "BB-84C",
+      "repo": "bgs-modding-superpowers",
+      "description": "Agentic Bethesda Game Studio modpack curation toolkit with MCP-driven xEdit conflict audit, MO2 control plane, BA2/BSA and Papyrus tooling, and skills for setup, dev-log, and release-changelog workflows.",
+      "category": "Development & Workflow",
+      "source": "awesome-ai-plugins",
+      "install_url": "https://raw.githubusercontent.com/BB-84C/bgs-modding-superpowers/HEAD/.codex-plugin/plugin.json",
       "platform": "codex",
       "ecosystems": [
         "codex"
@@ -1047,20 +1047,6 @@
       ]
     },
     {
-      "name": "Wingman",
-      "url": "https://github.com/lsshym/wingman.ai",
-      "owner": "lsshym",
-      "repo": "wingman.ai",
-      "description": "Cross-platform AI coding-agent plugin for repo-local project memory, data-contract checks, and project-map discovery before agents edit code.",
-      "category": "Development & Workflow",
-      "source": "awesome-ai-plugins",
-      "install_url": "https://raw.githubusercontent.com/lsshym/wingman.ai/HEAD/.codex-plugin/plugin.json",
-      "platform": "codex",
-      "ecosystems": [
-        "codex"
-      ]
-    },
-    {
       "name": "Waggle",
       "url": "https://github.com/Abhigyan-Shekhar/Waggle-mcp",
       "owner": "Abhigyan-Shekhar",
@@ -1069,6 +1055,20 @@
       "category": "Development & Workflow",
       "source": "awesome-ai-plugins",
       "install_url": "https://raw.githubusercontent.com/Abhigyan-Shekhar/Waggle-mcp/HEAD/.codex-plugin/plugin.json",
+      "platform": "codex",
+      "ecosystems": [
+        "codex"
+      ]
+    },
+    {
+      "name": "Wingman",
+      "url": "https://github.com/lsshym/wingman.ai",
+      "owner": "lsshym",
+      "repo": "wingman.ai",
+      "description": "Cross-platform AI coding-agent plugin for repo-local project memory, data-contract checks, and project-map discovery before agents edit code.",
+      "category": "Development & Workflow",
+      "source": "awesome-ai-plugins",
+      "install_url": "https://raw.githubusercontent.com/lsshym/wingman.ai/HEAD/.codex-plugin/plugin.json",
       "platform": "codex",
       "ecosystems": [
         "codex"
@@ -1383,20 +1383,6 @@
       ]
     },
     {
-      "name": "Context Pack",
-      "url": "https://github.com/Rothschildiuk/context-pack",
-      "owner": "Rothschildiuk",
-      "repo": "context-pack",
-      "description": "Generate compact first-pass repository briefings for coding agents before deeper exploration.",
-      "category": "Tools & Integrations",
-      "source": "awesome-ai-plugins",
-      "install_url": "https://raw.githubusercontent.com/Rothschildiuk/context-pack/HEAD/.codex-plugin/plugin.json",
-      "platform": "codex",
-      "ecosystems": [
-        "codex"
-      ]
-    },
-    {
       "name": "CONTAM Tools",
       "url": "https://github.com/summer521521/CONTAM_plugin",
       "owner": "summer521521",
@@ -1405,6 +1391,20 @@
       "category": "Tools & Integrations",
       "source": "awesome-ai-plugins",
       "install_url": "https://raw.githubusercontent.com/summer521521/CONTAM_plugin/HEAD/.codex-plugin/plugin.json",
+      "platform": "codex",
+      "ecosystems": [
+        "codex"
+      ]
+    },
+    {
+      "name": "Context Pack",
+      "url": "https://github.com/Rothschildiuk/context-pack",
+      "owner": "Rothschildiuk",
+      "repo": "context-pack",
+      "description": "Generate compact first-pass repository briefings for coding agents before deeper exploration.",
+      "category": "Tools & Integrations",
+      "source": "awesome-ai-plugins",
+      "install_url": "https://raw.githubusercontent.com/Rothschildiuk/context-pack/HEAD/.codex-plugin/plugin.json",
       "platform": "codex",
       "ecosystems": [
         "codex"
@@ -1775,20 +1775,6 @@
       ]
     },
     {
-      "name": "Pronounce",
-      "url": "https://github.com/anzy-renlab-ai/pronounce",
-      "owner": "anzy-renlab-ai",
-      "repo": "pronounce",
-      "description": "Pronounce developer jargon out loud: an MCP server (lookup/search) and skill backed by a 1,721-entry sourced dictionary with IPA, audio, and cited pronunciations for kubectl, nginx, YAML, JWT, and more.",
-      "category": "Tools & Integrations",
-      "source": "awesome-ai-plugins",
-      "install_url": "https://raw.githubusercontent.com/anzy-renlab-ai/pronounce/HEAD/.codex-plugin/plugin.json",
-      "platform": "codex",
-      "ecosystems": [
-        "codex"
-      ]
-    },
-    {
       "name": "prompt-to-asset",
       "url": "https://github.com/MohamedAbdallah-14/prompt-to-asset",
       "owner": "MohamedAbdallah-14",
@@ -1797,6 +1783,20 @@
       "category": "Tools & Integrations",
       "source": "awesome-ai-plugins",
       "install_url": "https://raw.githubusercontent.com/MohamedAbdallah-14/prompt-to-asset/HEAD/plugins/prompt-to-asset/.codex-plugin/plugin.json",
+      "platform": "codex",
+      "ecosystems": [
+        "codex"
+      ]
+    },
+    {
+      "name": "Pronounce",
+      "url": "https://github.com/anzy-renlab-ai/pronounce",
+      "owner": "anzy-renlab-ai",
+      "repo": "pronounce",
+      "description": "Pronounce developer jargon out loud: an MCP server (lookup/search) and skill backed by a 1,721-entry sourced dictionary with IPA, audio, and cited pronunciations for kubectl, nginx, YAML, JWT, and more.",
+      "category": "Tools & Integrations",
+      "source": "awesome-ai-plugins",
+      "install_url": "https://raw.githubusercontent.com/anzy-renlab-ai/pronounce/HEAD/.codex-plugin/plugin.json",
       "platform": "codex",
       "ecosystems": [
         "codex"

--- a/scripts/post-claim-notice.py
+++ b/scripts/post-claim-notice.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""
+Post a "claim your plugin" comment on merged PRs that add plugins present in the
+HOL registry but not yet owner-verified.
+
+Triggers via GitHub Actions on pull_request closed (merged).
+Checks the HOL registry catalog API for matching repos, then posts a comment
+with claim instructions if the plugin hasn't been claimed yet.
+"""
+
+import json
+import os
+import re
+import sys
+import urllib.request
+import urllib.error
+
+# --- Config ---
+REGISTRY_API = os.environ.get("REGISTRY_API", "https://hol.org/registry/api/v1")
+GH_TOKEN = os.environ.get("GH_TOKEN", "")
+PR_NUMBER = os.environ.get("PR_NUMBER", "")
+PR_TITLE = os.environ.get("PR_TITLE", "")
+PR_AUTHOR = os.environ.get("PR_AUTHOR", "")
+REPO_FULL = os.environ.get("GITHUB_REPOSITORY", "")
+
+# Skip titles that aren't new plugin additions
+SKIP_PATTERNS = [
+    r"^docs?:",
+    r"^fix\b",
+    r"^ci\b",
+    r"^chore\b",
+    r"^refactor\b",
+    r"^test\b",
+    r"^build\b",
+    r"Add icon for",
+    r"Add .* icon",
+    r"Add .* marketplace icon",
+    r"For praxis, add marketplace icon",
+    r"Update .*(listing|plugin owner|description|to v|trust signals)",
+    r"Sync ",
+    r"#\d+ Fix ",
+    r"Fix install_url",
+    r"Fix Casefile README",
+    r"Canvas-Apps-Plugin-Codex - Update",
+    r"docs: reframe scanner",
+    r"docs: add PANews",
+    r"fix\(registry\)",
+    r"fix\(readme\)",
+    r"fix\(plugins\)",
+    r"feat: Make HOL Plugin Scanner",
+    r"feat: publish curated marketplace",
+    r"feat: add HOL Guard Plugin",
+    r"ci\(sync\)",
+    r"ci\(workflows\)",
+    r"Add HOL Guard scanner",
+]
+
+COMMENT_BODY = """<!-- hol-claim-notice -->
+🎉 Your plugin has been merged and is now listed in the [HOL Registry](https://hol.org/registry/plugins)!
+
+## Claim your plugin
+
+As the author, you can verify ownership of your plugin to unlock:
+
+- **Owner-verified badge** on your plugin's registry listing
+- **Trust score** visibility and analytics for your plugin
+- **Direct claim link** to share with your community
+- **Dashboard access** at [hol.org/guard/plugins](https://hol.org/guard/plugins) to track installs, trust, and engagement
+
+### How to claim
+
+1. Visit **[hol.org/guard/plugins](https://hol.org/guard/plugins)**
+2. Find your plugin and click **"Verify ownership"**
+3. Sign in with GitHub — we only request `read:user`, `user:email`, and `read:org` (no write access to your repos)
+4. We verify you own the repository, and your plugin gets the ✅ owner-verified badge
+
+The whole process takes under 30 seconds. No need to add any secrets or tokens to your repo — verification is done entirely through GitHub OAuth.
+
+If you have any questions, feel free to ask here or reach out at [support@hol.org](mailto:support@hol.org)."""
+
+MARKER = "<!-- hol-claim-notice -->"
+
+
+def api_request(url, headers=None, method="GET", data=None):
+    """Make an HTTP request and return parsed JSON."""
+    req_headers = {"Accept": "application/json"}
+    if headers:
+        req_headers.update(headers)
+    if data is not None:
+        data = json.dumps(data).encode("utf-8")
+        req_headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, headers=req_headers, method=method, data=data)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")
+        print(f"  HTTP {e.code} from {url}: {body[:200]}", file=sys.stderr)
+        return None
+    except Exception as e:
+        print(f"  Error fetching {url}: {e}", file=sys.stderr)
+        return None
+
+
+def should_skip_title(title: str) -> bool:
+    """Return True if the PR title matches a non-plugin pattern."""
+    for pattern in SKIP_PATTERNS:
+        if re.search(pattern, title, re.IGNORECASE):
+            return True
+    return False
+
+
+def fetch_registry_plugins():
+    """Fetch all plugins from the registry catalog, return set of lowercase repo full names."""
+    repos = set()
+    cursor = None
+    for _ in range(10):
+        url = f"{REGISTRY_API}/plugins/catalog?limit=50"
+        if cursor:
+            url += f"&cursor={cursor}"
+        data = api_request(url)
+        if not data or "items" not in data:
+            break
+        for plugin in data["items"]:
+            repo = plugin.get("sourceRepo") or plugin.get("repository") or ""
+            repo = repo.replace("https://github.com/", "").strip()
+            if repo:
+                repos.add(repo.lower())
+        cursor = data.get("nextCursor")
+        if not cursor:
+            break
+    return repos
+
+
+def fetch_verified_repos():
+    """Fetch owner-verified plugins from the registry, return set of lowercase repos."""
+    repos = set()
+    cursor = None
+    for _ in range(10):
+        url = f"{REGISTRY_API}/plugins/catalog?limit=50&ownerVerified=true"
+        if cursor:
+            url += f"&cursor={cursor}"
+        data = api_request(url)
+        if not data or "items" not in data:
+            break
+        for plugin in data["items"]:
+            repo = plugin.get("sourceRepo") or plugin.get("repository") or ""
+            repo = repo.replace("https://github.com/", "").strip()
+            if repo:
+                repos.add(repo.lower())
+        cursor = data.get("nextCursor")
+        if not cursor:
+            break
+    return repos
+
+
+def parse_pr_diff_for_repos():
+    """Get the PR diff and extract GitHub repo URLs from added lines."""
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "diff", PR_NUMBER, "--repo", REPO_FULL],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env={**os.environ, "GH_TOKEN": GH_TOKEN},
+        )
+        diff = result.stdout
+    except Exception as e:
+        print(f"  Failed to get PR diff: {e}", file=sys.stderr)
+        return set()
+
+    repos = set()
+    # Match https://github.com/owner/repo in added lines (starting with +)
+    for line in diff.split("\n"):
+        if not line.startswith("+"):
+            continue
+        matches = re.findall(r"https://github\.com/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)", line)
+        for match in matches:
+            # Skip hashgraph-online repos (our own)
+            if not match.lower().startswith("hashgraph-online/"):
+                repos.add(match.lower())
+
+    return repos
+
+
+def has_existing_claim_comment():
+    """Check if the PR already has a claim-notice comment."""
+    url = f"https://api.github.com/repos/{REPO_FULL}/issues/{PR_NUMBER}/comments"
+    headers = {"Authorization": f"token {GH_TOKEN}"}
+    comments = api_request(url, headers=headers)
+    if not isinstance(comments, list):
+        return False
+    for comment in comments:
+        body = comment.get("body", "")
+        if MARKER in body:
+            return True
+    return False
+
+
+def post_comment():
+    """Post the claim notice comment on the PR."""
+    url = f"https://api.github.com/repos/{REPO_FULL}/issues/{PR_NUMBER}/comments"
+    headers = {"Authorization": f"token {GH_TOKEN}"}
+    result = api_request(url, headers=headers, method="POST", data={"body": COMMENT_BODY})
+    return result is not None
+
+
+def main():
+    print(f"PR #{PR_NUMBER}: \"{PR_TITLE}\" by @{PR_AUTHOR}")
+
+    # 1. Skip non-plugin PRs
+    if should_skip_title(PR_TITLE):
+        print("  Skipping: non-plugin PR title pattern")
+        return 0
+
+    if PR_AUTHOR == "kantorcodes" or PR_AUTHOR == "github-actions[bot]":
+        print("  Skipping: bot/owner PR")
+        return 0
+
+    # 2. Check for existing claim comment
+    if has_existing_claim_comment():
+        print("  Skipping: claim notice already posted")
+        return 0
+
+    # 3. Parse PR diff for GitHub repo URLs
+    pr_repos = parse_pr_diff_for_repos()
+    if not pr_repos:
+        print("  Skipping: no GitHub repo URLs found in PR diff")
+        return 0
+
+    print(f"  Found repos in diff: {', '.join(pr_repos)}")
+
+    # 4. Fetch all registry plugins
+    print("  Fetching registry catalog...")
+    registry_repos = fetch_registry_plugins()
+    print(f"  Registry has {len(registry_repos)} plugins")
+
+    # 5. Check which PR repos are in the registry
+    matched = pr_repos & registry_repos
+    if not matched:
+        print("  Skipping: none of the PR repos are in the registry")
+        return 0
+
+    print(f"  Matched in registry: {', '.join(matched)}")
+
+    # 6. Check if already owner-verified
+    print("  Checking owner verification status...")
+    verified_repos = fetch_verified_repos()
+    already_verified = matched & verified_repos
+    if already_verified and len(already_verified) == len(matched):
+        print(f"  Skipping: all matched repos already owner-verified")
+        return 0
+
+    if already_verified:
+        print(f"  Some already verified: {', '.join(already_verified)}")
+
+    # 7. Post the comment
+    print("  Posting claim notice comment...")
+    if post_comment():
+        print("  ✅ Comment posted successfully")
+        return 0
+    else:
+        print("  ❌ Failed to post comment")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/post-claim-notice.py
+++ b/scripts/post-claim-notice.py
@@ -12,6 +12,7 @@ import json
 import os
 import re
 import sys
+import subprocess
 import urllib.request
 import urllib.error
 
@@ -110,14 +111,20 @@ def should_skip_title(title: str) -> bool:
     return False
 
 
-def fetch_registry_plugins():
-    """Fetch all plugins from the registry catalog, return set of lowercase repo full names."""
+def fetch_catalog_repos(owner_verified: bool = False):
+    """Fetch repos from the registry catalog, optionally filtered by owner verification.
+
+    Returns a set of lowercase 'owner/repo' strings.
+    """
     repos = set()
     cursor = None
+    base_url = f"{REGISTRY_API}/plugins/catalog?limit=50"
+    if owner_verified:
+        base_url += "&ownerVerified=true"
+    url = base_url
     for _ in range(10):
-        url = f"{REGISTRY_API}/plugins/catalog?limit=50"
         if cursor:
-            url += f"&cursor={cursor}"
+            url = f"{base_url}&cursor={cursor}"
         data = api_request(url)
         if not data or "items" not in data:
             break
@@ -132,44 +139,37 @@ def fetch_registry_plugins():
     return repos
 
 
-def fetch_verified_repos():
-    """Fetch owner-verified plugins from the registry, return set of lowercase repos."""
-    repos = set()
-    cursor = None
-    for _ in range(10):
-        url = f"{REGISTRY_API}/plugins/catalog?limit=50&ownerVerified=true"
-        if cursor:
-            url += f"&cursor={cursor}"
-        data = api_request(url)
-        if not data or "items" not in data:
-            break
-        for plugin in data["items"]:
-            repo = plugin.get("sourceRepo") or plugin.get("repository") or ""
-            repo = repo.replace("https://github.com/", "").strip()
-            if repo:
-                repos.add(repo.lower())
-        cursor = data.get("nextCursor")
-        if not cursor:
-            break
-    return repos
+def normalize_repo_url(raw: str) -> str:
+    """Normalize a GitHub URL or 'owner/repo' string to lowercase 'owner/repo'.
+
+    Strips trailing slashes, .git suffix, and extra path segments.
+    """
+    s = raw.strip().rstrip("/")
+    if s.endswith(".git"):
+        s = s[:-4]
+    # If it's a full URL, extract owner/repo
+    match = re.match(r"https?://github\.com/([^/]+/[^/]+)", s, re.IGNORECASE)
+    if match:
+        s = match.group(1)
+    else:
+        # Handle bare 'owner/repo/extra/path' — take first two segments
+        parts = s.split("/")
+        if len(parts) >= 2:
+            s = f"{parts[0]}/{parts[1]}"
+    return s.lower()
 
 
 def parse_pr_diff_for_repos():
     """Get the PR diff and extract GitHub repo URLs from added lines."""
-    import subprocess
-
-    try:
-        result = subprocess.run(
-            ["gh", "pr", "diff", PR_NUMBER, "--repo", REPO_FULL],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            env={**os.environ, "GH_TOKEN": GH_TOKEN},
-        )
-        diff = result.stdout
-    except Exception as e:
-        print(f"  Failed to get PR diff: {e}", file=sys.stderr)
-        return set()
+    result = subprocess.run(
+        ["gh", "pr", "diff", PR_NUMBER, "--repo", REPO_FULL],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={**os.environ, "GH_TOKEN": GH_TOKEN},
+        check=True,
+    )
+    diff = result.stdout
 
     repos = set()
     # Match https://github.com/owner/repo in added lines (starting with +)
@@ -178,9 +178,10 @@ def parse_pr_diff_for_repos():
             continue
         matches = re.findall(r"https://github\.com/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)", line)
         for match in matches:
+            normalized = normalize_repo_url(match)
             # Skip hashgraph-online repos (our own)
-            if not match.lower().startswith("hashgraph-online/"):
-                repos.add(match.lower())
+            if not normalized.startswith("hashgraph-online/"):
+                repos.add(normalized)
 
     return repos
 
@@ -193,7 +194,7 @@ def has_existing_claim_comment():
     if not isinstance(comments, list):
         return False
     for comment in comments:
-        body = comment.get("body", "")
+        body = comment.get("body") or ""
         if MARKER in body:
             return True
     return False
@@ -208,14 +209,26 @@ def post_comment():
 
 
 def main():
-    print(f"PR #{PR_NUMBER}: \"{PR_TITLE}\" by @{PR_AUTHOR}")
+    # Validate required environment variables
+    missing = []
+    if not GH_TOKEN:
+        missing.append("GH_TOKEN")
+    if not PR_NUMBER:
+        missing.append("PR_NUMBER")
+    if not REPO_FULL:
+        missing.append("GITHUB_REPOSITORY")
+    if missing:
+        print(f"Error: missing required environment variables: {', '.join(missing)}", file=sys.stderr)
+        return 1
+
+    print(f'PR #{PR_NUMBER}: "{PR_TITLE}" by @{PR_AUTHOR}')
 
     # 1. Skip non-plugin PRs
     if should_skip_title(PR_TITLE):
         print("  Skipping: non-plugin PR title pattern")
         return 0
 
-    if PR_AUTHOR == "kantorcodes" or PR_AUTHOR == "github-actions[bot]":
+    if PR_AUTHOR in ("kantorcodes", "github-actions[bot]"):
         print("  Skipping: bot/owner PR")
         return 0
 
@@ -225,7 +238,15 @@ def main():
         return 0
 
     # 3. Parse PR diff for GitHub repo URLs
-    pr_repos = parse_pr_diff_for_repos()
+    try:
+        pr_repos = parse_pr_diff_for_repos()
+    except subprocess.CalledProcessError as e:
+        print(f"  Failed to get PR diff (exit {e.returncode}): {e.stderr}", file=sys.stderr)
+        return 0
+    except subprocess.TimeoutExpired:
+        print("  Failed to get PR diff: timed out", file=sys.stderr)
+        return 0
+
     if not pr_repos:
         print("  Skipping: no GitHub repo URLs found in PR diff")
         return 0
@@ -234,7 +255,7 @@ def main():
 
     # 4. Fetch all registry plugins
     print("  Fetching registry catalog...")
-    registry_repos = fetch_registry_plugins()
+    registry_repos = fetch_catalog_repos(owner_verified=False)
     print(f"  Registry has {len(registry_repos)} plugins")
 
     # 5. Check which PR repos are in the registry
@@ -247,10 +268,10 @@ def main():
 
     # 6. Check if already owner-verified
     print("  Checking owner verification status...")
-    verified_repos = fetch_verified_repos()
+    verified_repos = fetch_catalog_repos(owner_verified=True)
     already_verified = matched & verified_repos
     if already_verified and len(already_verified) == len(matched):
-        print(f"  Skipping: all matched repos already owner-verified")
+        print("  Skipping: all matched repos already owner-verified")
         return 0
 
     if already_verified:


### PR DESCRIPTION
## Summary

Automates the plugin claim notice workflow. When a PR adding a plugin is merged, this Action:

1. **Parses the PR diff** for GitHub repo URLs (e.g. `https://github.com/owner/repo`)
2. **Checks the HOL registry** at `hol.org/registry/api/v1/plugins/catalog` to see if the repo is a registered plugin
3. **Checks owner verification** via `?ownerVerified=true` — skips if already verified
4. **Posts a comment** with claim instructions (badge, trust score, dashboard access) and a link to `hol.org/guard/plugins`
5. **Idempotent** — uses a hidden HTML comment marker (`<!-- hol-claim-notice -->`) to avoid duplicate comments

### What gets skipped
- Non-plugin PRs (docs, fix, icon, CI, chore — matched by title pattern)
- PRs by `kantorcodes` or `github-actions[bot]`
- Plugins not in the HOL registry
- Plugins already owner-verified
- PRs that already have a claim-notice comment

### Files
- `.github/workflows/claim-notice.yml` — triggers on `pull_request: closed` when `README.md` or `plugins/**` change
- `scripts/post-claim-notice.py` — Python script that does the registry check and comment posting

### No secrets needed
Uses the built-in `GITHUB_TOKEN` with `pull-requests: write` permission. The registry API is public (no auth required for catalog reads).

## Test plan
- [ ] Merge this PR
- [ ] Open a test PR that adds a plugin entry to README, merge it
- [ ] Verify the claim-notice comment appears on the merged PR
- [ ] Verify re-running on an already-commented PR is a no-op