### PR TITLE
fix: tag PR author in claim notice comment

### DIFF
--- a/scripts/post-claim-notice.py
+++ b/scripts/post-claim-notice.py
@@ -56,8 +56,10 @@ SKIP_PATTERNS = [
     r"Add HOL Guard scanner",
 ]
 
-COMMENT_BODY = """<!-- hol-claim-notice -->
-🎉 Your plugin has been merged and is now listed in the [HOL Registry](https://hol.org/registry/plugins)!
+def build_comment_body(author: str) -> str:
+    """Build the claim notice comment body, tagging the PR author."""
+    return f"""<!-- hol-claim-notice -->
+🎉 Hey @{author}, your plugin has been merged and is now listed in the [HOL Registry](https://hol.org/registry/plugins)!
 
 ## Claim your plugin
 
@@ -200,11 +202,12 @@ def has_existing_claim_comment():
     return False
 
 
-def post_comment():
-    """Post the claim notice comment on the PR."""
+def post_comment(author: str):
+    """Post the claim notice comment on the PR, tagging the author."""
     url = f"https://api.github.com/repos/{REPO_FULL}/issues/{PR_NUMBER}/comments"
     headers = {"Authorization": f"token {GH_TOKEN}"}
-    result = api_request(url, headers=headers, method="POST", data={"body": COMMENT_BODY})
+    body = build_comment_body(author)
+    result = api_request(url, headers=headers, method="POST", data={"body": body})
     return result is not None
 
 
@@ -279,7 +282,7 @@ def main():
 
     # 7. Post the comment
     print("  Posting claim notice comment...")
-    if post_comment():
+    if post_comment(PR_AUTHOR):
         print("  ✅ Comment posted successfully")
         return 0
     else:

--- a/scripts/post-claim-notice.py
+++ b/scripts/post-claim-notice.py
@@ -86,7 +86,7 @@ MARKER = "<!-- hol-claim-notice -->"
 
 def api_request(url, headers=None, method="GET", data=None):
     """Make an HTTP request and return parsed JSON."""
-    req_headers = {"Accept": "application/json"}
+    req_headers = {"Accept": "application/json", "User-Agent": "hol-claim-notice/1.0"}
     if headers:
         req_headers.update(headers)
     if data is not None:
@@ -189,7 +189,7 @@ def parse_pr_diff_for_repos():
 
 
 def has_existing_claim_comment():
-    """Check if the PR already has a claim-notice comment."""
+    """Check if the PR already has a claim-notice or manual claim comment."""
     url = f"https://api.github.com/repos/{REPO_FULL}/issues/{PR_NUMBER}/comments"
     headers = {"Authorization": f"token {GH_TOKEN}"}
     comments = api_request(url, headers=headers)
@@ -198,6 +198,9 @@ def has_existing_claim_comment():
     for comment in comments:
         body = comment.get("body") or ""
         if MARKER in body:
+            return True
+        # Also detect manual claim comments posted before automation
+        if "Claim your plugin" in body and "hol.org/guard/plugins" in body:
             return True
     return False
 

--- a/scripts/post-claim-notice.py
+++ b/scripts/post-claim-notice.py
@@ -86,7 +86,7 @@ MARKER = "<!-- hol-claim-notice -->"
 
 def api_request(url, headers=None, method="GET", data=None):
     """Make an HTTP request and return parsed JSON."""
-    req_headers = {"Accept": "application/json", "User-Agent": "hol-claim-notice/1.0"}
+    req_headers = {"Accept": "application/json"}
     if headers:
         req_headers.update(headers)
     if data is not None:
@@ -189,7 +189,7 @@ def parse_pr_diff_for_repos():
 
 
 def has_existing_claim_comment():
-    """Check if the PR already has a claim-notice or manual claim comment."""
+    """Check if the PR already has a claim-notice comment."""
     url = f"https://api.github.com/repos/{REPO_FULL}/issues/{PR_NUMBER}/comments"
     headers = {"Authorization": f"token {GH_TOKEN}"}
     comments = api_request(url, headers=headers)
@@ -198,9 +198,6 @@ def has_existing_claim_comment():
     for comment in comments:
         body = comment.get("body") or ""
         if MARKER in body:
-            return True
-        # Also detect manual claim comments posted before automation
-        if "Claim your plugin" in body and "hol.org/guard/plugins" in body:
             return True
     return False
 
@@ -221,6 +218,8 @@ def main():
         missing.append("GH_TOKEN")
     if not PR_NUMBER:
         missing.append("PR_NUMBER")
+    if not PR_AUTHOR:
+        missing.append("PR_AUTHOR")
     if not REPO_FULL:
         missing.append("GITHUB_REPOSITORY")
     if missing:


### PR DESCRIPTION
## Summary

The claim notice comment was a static string that didn't mention the PR author. GitHub doesn't send notifications for comments that don't tag anyone, so the author would never know about the claim instructions.

## Fix

- Replace static `COMMENT_BODY` with `build_comment_body(author)` function
- Comment now starts with `Hey @<author>, your plugin has been merged...`
- This triggers a GitHub notification email to the PR author

## Test plan
- [x] Smoke test: `build_comment_body('testuser')` produces string containing `@testuser`
- [ ] Merge and verify a future plugin PR gets the tagged comment