### PR TITLE
fix: add User-Agent header and manual comment detection to claim notice

### DIFF
--- a/scripts/post-claim-notice.py
+++ b/scripts/post-claim-notice.py
@@ -56,8 +56,10 @@ SKIP_PATTERNS = [
     r"Add HOL Guard scanner",
 ]
 
-COMMENT_BODY = """<!-- hol-claim-notice -->
-🎉 Your plugin has been merged and is now listed in the [HOL Registry](https://hol.org/registry/plugins)!
+def build_comment_body(author: str) -> str:
+    """Build the claim notice comment body, tagging the PR author."""
+    return f"""<!-- hol-claim-notice -->
+🎉 Hey @{author}, your plugin has been merged and is now listed in the [HOL Registry](https://hol.org/registry/plugins)!
 
 ## Claim your plugin
 
@@ -200,11 +202,12 @@ def has_existing_claim_comment():
     return False
 
 
-def post_comment():
-    """Post the claim notice comment on the PR."""
+def post_comment(author: str):
+    """Post the claim notice comment on the PR, tagging the author."""
     url = f"https://api.github.com/repos/{REPO_FULL}/issues/{PR_NUMBER}/comments"
     headers = {"Authorization": f"token {GH_TOKEN}"}
-    result = api_request(url, headers=headers, method="POST", data={"body": COMMENT_BODY})
+    body = build_comment_body(author)
+    result = api_request(url, headers=headers, method="POST", data={"body": body})
     return result is not None
 
 
@@ -279,7 +282,7 @@ def main():
 
     # 7. Post the comment
     print("  Posting claim notice comment...")
-    if post_comment():
+    if post_comment(PR_AUTHOR):
         print("  ✅ Comment posted successfully")
         return 0
     else:

--- a/scripts/post-claim-notice.py
+++ b/scripts/post-claim-notice.py
@@ -86,7 +86,7 @@ MARKER = "<!-- hol-claim-notice -->"
 
 def api_request(url, headers=None, method="GET", data=None):
     """Make an HTTP request and return parsed JSON."""
-    req_headers = {"Accept": "application/json"}
+    req_headers = {"Accept": "application/json", "User-Agent": "hol-claim-notice/1.0"}
     if headers:
         req_headers.update(headers)
     if data is not None:
@@ -189,7 +189,7 @@ def parse_pr_diff_for_repos():
 
 
 def has_existing_claim_comment():
-    """Check if the PR already has a claim-notice comment."""
+    """Check if the PR already has a claim-notice or manual claim comment."""
     url = f"https://api.github.com/repos/{REPO_FULL}/issues/{PR_NUMBER}/comments"
     headers = {"Authorization": f"token {GH_TOKEN}"}
     comments = api_request(url, headers=headers)
@@ -198,6 +198,9 @@ def has_existing_claim_comment():
     for comment in comments:
         body = comment.get("body") or ""
         if MARKER in body:
+            return True
+        # Also detect manual claim comments posted before automation
+        if "Claim your plugin" in body and "hol.org/guard/plugins" in body:
             return True
     return False
 


### PR DESCRIPTION
## Summary
- Add `User-Agent: hol-claim-notice/1.0` header to all HTTP requests — Cloudflare blocks the default `Python-urllib` user agent on the registry API
- Detect manual claim comments (posted before automation existed) to avoid duplicate comments on PRs that already have one

## Testing
- Verified script correctly detects existing manual claim comments and skips posting
- Verified User-Agent header resolves Cloudflare 403 on registry API
