### PR TITLE
fix: claim-notice permissions and README fallback

### DIFF
--- a/.github/workflows/claim-notice.yml
+++ b/.github/workflows/claim-notice.yml
@@ -1,7 +1,7 @@
 name: Plugin Claim Notice
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     paths:

--- a/scripts/post-claim-notice.py
+++ b/scripts/post-claim-notice.py
@@ -267,8 +267,22 @@ def main():
     # 5. Check which PR repos are in the registry
     matched = pr_repos & registry_repos
     if not matched:
-        print("  Skipping: none of the PR repos are in the registry")
-        return 0
+        # Fallback: check local README.md — the plugin may have just been merged
+        # and the registry sync hasn't completed yet
+        print("  Not in registry yet, checking local README.md...")
+        readme_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "README.md")
+        if os.path.exists(readme_path):
+            readme_content = open(readme_path, encoding="utf-8").read().lower()
+            readme_matched = {r for r in pr_repos if r.lower() in readme_content}
+            if readme_matched:
+                print(f"  Found in README (pending registry sync): {', '.join(readme_matched)}")
+                matched = readme_matched
+            else:
+                print("  Skipping: none of the PR repos are in the registry or README")
+                return 0
+        else:
+            print("  Skipping: README.md not found and repos not in registry")
+            return 0
 
     print(f"  Matched in registry: {', '.join(matched)}")
 


### PR DESCRIPTION
## Summary

Two bugs fixed (same as awesome-codex-plugins #267 minus the mirror fix):

1. **claim-notice.yml**: `pull_request` → `pull_request_target` — fork PRs get read-only token on `pull_request` events
2. **post-claim-notice.py**: README fallback when plugin not yet in registry — registry sync lags behind PR merge

## Test plan
- [x] Smoke test passed
- [ ] Merge and verify next merged PR gets claim-notice comment