### PR TITLE
Add Tree Ring Memory plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
   "source": "awesome-ai-plugins",
-  "last_updated": "2026-07-08T01:19:50.309642+00:00",
+  "last_updated": "2026-07-08T04:53:25.549142+00:00",
   "plugins": [
     {
       "name": "Registry Broker",
@@ -1565,6 +1565,21 @@
       "install_url": "https://raw.githubusercontent.com/Rothschildiuk/context-pack/HEAD/.codex-plugin/plugin.json"
     },
     {
+      "name": "Coolify",
+      "displayName": "Coolify",
+      "description": "Control Coolify Cloud and self-hosted Coolify instances through API-aware workflow skills and local tools.",
+      "category": "Tools & Integrations",
+      "source": "awesome-ai-plugins",
+      "platform": "codex",
+      "ecosystems": [
+        "codex"
+      ],
+      "owner": "Sevi-py",
+      "repo": "coolify-codex-plugin",
+      "url": "https://github.com/Sevi-py/coolify-codex-plugin",
+      "install_url": "https://raw.githubusercontent.com/Sevi-py/coolify-codex-plugin/HEAD/.codex-plugin/plugin.json"
+    },
+    {
       "name": "Data Product Builder for dbt",
       "displayName": "Data Product Builder for dbt",
       "description": "Full data-product lifecycle on dbt for Entropy Data: scaffold, audit, and integrate projects with ODCS, ODPS, OpenLineage, and GitHub Actions.",
@@ -2330,19 +2345,19 @@
       "install_url": "https://raw.githubusercontent.com/hashgraph-online/hol-guard-grok-plugin/HEAD/.grok-plugin/plugin.json"
     },
     {
-      "name": "Coolify",
-      "displayName": "Coolify",
-      "description": "Control Coolify Cloud and self-hosted Coolify instances through API-aware workflow skills and local tools",
-      "category": "Tools & Integrations",
+      "name": "Tree Ring Memory",
+      "displayName": "Tree Ring Memory",
+      "description": "Codex plugin wrapper for local-first agent memory lifecycle guidance: scoped recall, explicit writes, evidence records, audit, forgetting, and consolidation without transcript dumping",
+      "category": "Development & Workflow",
       "source": "awesome-ai-plugins",
       "platform": "codex",
       "ecosystems": [
         "codex"
       ],
-      "owner": "Sevi-py",
-      "repo": "coolify-codex-plugin",
-      "url": "https://github.com/Sevi-py/coolify-codex-plugin",
-      "install_url": "https://raw.githubusercontent.com/Sevi-py/coolify-codex-plugin/HEAD/.codex-plugin/plugin.json"
+      "owner": "TerminallyLazy",
+      "repo": "tree-ring-memory-codex-plugin",
+      "url": "https://github.com/TerminallyLazy/tree-ring-memory-codex-plugin",
+      "install_url": "https://raw.githubusercontent.com/TerminallyLazy/tree-ring-memory-codex-plugin/HEAD/.codex-plugin/plugin.json"
     },
     {
       "name": "sitemd",

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Test Gap](./plugins/mturac/test-gap) - Find lines in your diff lacking test coverage (Cobertura, lcov, coverage.json).
 - [TODO Harvest](./plugins/mturac/todo-harvest) - TODO/FIXME/HACK scan with `git blame` author + age.
 - [Tool Advisor](https://github.com/dragon1086/claude-skills) - Read-only meta-skill that scans your MCP servers, skills, plugins, and CLI tools, then suggests up to three ranked approaches (Methodical / Fast / Deep) with a copy-paste Quick Action table.
+- [Tree Ring Memory](https://github.com/TerminallyLazy/tree-ring-memory-codex-plugin) - Codex plugin wrapper for local-first agent memory lifecycle guidance: scoped recall, explicit writes, evidence records, audit, forgetting, and consolidation without transcript dumping.
 - [Unity Agent Workflows](https://github.com/AUN-PN/unity-agent-workflows) - Codex plugin and skill for Unity 2D agents that enforces "No proof, no edit" workflows with runtime-owner proof, Teach structure maps, and validation gates.
 - [Universal Design Principles](https://github.com/HDeibler/universal-design-principles) - Cross-agent UX and product-design marketplace with a root Codex collection plugin, five focused plugin bundles, and 137 Agent Skills for design review, accessibility, layout, interaction, cognition, and product polish.
 - [Velith](https://github.com/epicsagas/Velith) - AI-native publishing system with a 6-phase pipeline from ideation to EPUB/PDF across 8 genres.
@@ -267,8 +268,8 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Jenkins CLI](https://github.com/avivsinai/jenkins-cli) - GitHub CLI-style interface for Jenkins controllers with jobs, pipelines, runs, logs, artifacts, credentials, and nodes.
 - [Kachilu Browser](https://github.com/kachilu-inc/kachilu-browser) - Anti-bot-aware browser automation for AI agents with MCP tools, CAPTCHA-aware workflows, and WSL2 Windows browser support.
 - [KiCad Happy](https://github.com/aklofas/kicad-happy) - KiCad EDA skills for schematic analysis, PCB layout review, component sourcing, BOM management, and manufacturing preparation.
-- [Kreuzberg Cloud](https://github.com/kreuzberg-dev/plugins) - Managed document extraction for Codex with API-key setup, presigned uploads, job tracking, webhook workflows, and usage guidance.
 - [Kreuzberg](https://github.com/kreuzberg-dev/plugins) - Local document extraction for 91+ formats with skills for CLI usage, OCR, table extraction, output formats, and a local MCP server.
+- [Kreuzberg Cloud](https://github.com/kreuzberg-dev/plugins) - Managed document extraction for Codex with API-key setup, presigned uploads, job tracking, webhook workflows, and usage guidance.
 - [Kreuzcrawl](https://github.com/kreuzberg-dev/plugins) - Web crawling and scraping for Codex with skills for single-page scraping, site crawls, URL mapping, and headless browser fallback.
 - [Langfuse Observability](https://github.com/avivsinai/langfuse-mcp) - Query traces, debug exceptions, analyze sessions, and manage prompts via MCP tools.
 - [Launch Fast](https://github.com/BlockchainHB/launchfast_codex_plugin) - Official Launch Fast plugin adapter for rapid SaaS deployment.

--- a/plugins.json
+++ b/plugins.json
@@ -3,7 +3,7 @@
   "name": "awesome-ai-plugins",
   "version": "1.0.0",
   "last_updated": "2026-07-08",
-  "total": 157,
+  "total": 158,
   "platforms": [
     "codex",
     "grok"
@@ -1467,6 +1467,20 @@
       ]
     },
     {
+      "name": "Coolify",
+      "url": "https://github.com/Sevi-py/coolify-codex-plugin",
+      "owner": "Sevi-py",
+      "repo": "coolify-codex-plugin",
+      "description": "Control Coolify Cloud and self-hosted Coolify instances through API-aware workflow skills and local tools.",
+      "category": "Tools & Integrations",
+      "source": "awesome-ai-plugins",
+      "install_url": "https://raw.githubusercontent.com/Sevi-py/coolify-codex-plugin/HEAD/.codex-plugin/plugin.json",
+      "platform": "codex",
+      "ecosystems": [
+        "codex"
+      ]
+    },
+    {
       "name": "Data Product Builder for dbt",
       "url": "https://github.com/entropy-data/dataproduct-builder-dbt",
       "owner": "entropy-data",
@@ -2181,15 +2195,15 @@
       ]
     },
     {
-      "name": "Coolify",
-      "url": "https://github.com/Sevi-py/coolify-codex-plugin",
-      "owner": "Sevi-py",
-      "repo": "coolify-codex-plugin",
-      "description": "Control Coolify Cloud and self-hosted Coolify instances through API-aware workflow skills and local tools",
-      "category": "Tools & Integrations",
+      "name": "Tree Ring Memory",
+      "url": "https://github.com/TerminallyLazy/tree-ring-memory-codex-plugin",
+      "owner": "TerminallyLazy",
+      "repo": "tree-ring-memory-codex-plugin",
+      "description": "Codex plugin wrapper for local-first agent memory lifecycle guidance: scoped recall, explicit writes, evidence records, audit, forgetting, and consolidation without transcript dumping",
+      "category": "Development & Workflow",
       "platform": "codex",
       "source": "awesome-ai-plugins",
-      "install_url": "https://raw.githubusercontent.com/Sevi-py/coolify-codex-plugin/HEAD/.codex-plugin/plugin.json",
+      "install_url": "https://raw.githubusercontent.com/TerminallyLazy/tree-ring-memory-codex-plugin/HEAD/.codex-plugin/plugin.json",
       "ecosystems": [
         "codex"
       ]


### PR DESCRIPTION
## Summary
- Add Tree Ring Memory to Development & Workflow as a Codex plugin wrapper for local-first agent memory lifecycle guidance.
- Regenerate `plugins.json` and `.agents/plugins/marketplace.json` with the upstream generator.
- Fix one pre-existing adjacent alphabetical ordering issue in Tools & Integrations so the repository sort check passes.

## Verification
- `python3 scripts/generate_plugins_json.py`
- `python3 scripts/check-alphabetical.py README.md`
- `git diff --check`
- `python3 -m json.tool plugins.json`
- `python3 -m json.tool .agents/plugins/marketplace.json`
- Plugin repo link: HTTP 200
- Plugin manifest link: HTTP 200
- HOL Plugin Scanner public run: https://github.com/TerminallyLazy/tree-ring-memory-codex-plugin/actions/runs/28917677294

## Plugin repo
https://github.com/TerminallyLazy/tree-ring-memory-codex-plugin

Disclosure: I maintain Tree Ring Memory.