### PR TITLE
Rename Ditto to Emulo

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -557,14 +557,14 @@
       ]
     },
     {
-      "name": "Ditto",
-      "url": "https://github.com/ohad6k/ditto",
+      "name": "Emulo",
+      "url": "https://github.com/ohad6k/emulo",
       "owner": "ohad6k",
-      "repo": "ditto",
+      "repo": "emulo",
       "description": "Mines selected evidence from local coding-agent sessions into private work, design, and writing profiles for Codex, Claude Code, and GitHub Copilot.",
       "category": "Development & Workflow",
       "source": "awesome-ai-plugins",
-      "install_url": "https://raw.githubusercontent.com/ohad6k/ditto/HEAD/.codex-plugin/plugin.json",
+      "install_url": "https://raw.githubusercontent.com/ohad6k/emulo/HEAD/.codex-plugin/plugin.json",
       "platform": "codex",
       "ecosystems": [
         "codex"


### PR DESCRIPTION
`ditto` was renamed to **emulo** in v0.5.0. The old name collided with several existing products (heyditto.ai, ditto.live, and an unrelated `ditto` skill on ClawHub), so the project renamed rather than fight three namespaces.

Updates `plugins.json`: name, url, repo, and `install_url`. The old raw URL still redirects, so nothing is broken today, but the entry advertises a name the project no longer uses.

Same plugin, same description, same category. Repo: https://github.com/ohad6k/emulo