### PR TITLE
Add Codex Skin Pack Installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex Process Jobs](https://github.com/joelfarthing/codex-process-jobs) - Run long local builds, tests, benchmarks, and inference jobs as durable detached processes with tracked status, bounded results, and completion delivery across Codex surfaces.
 - [Codex Reviewer](https://github.com/schuettc/codex-reviewer) - Second-pass review of Claude-driven plans and implementations.
 - [Codex rg Guard](https://github.com/Rycen7822/codex-rg-guard) - Budgeted `rg`/`grep` replacement for Codex that narrows broad searches before they waste model context.
-- [Codex Skin Pack Installer](https://github.com/ChannelerH/codex-skin-packs) - Codex plugin and Skill that stages verified desktop skin packs from GitHub releases, validates files, and keeps restore guidance visible.
+- [Codex Skin Pack Installer](https://github.com/ChannelerH/codex-skin-packs) - Codex plugin and skill that stages verified desktop skin packs from GitHub releases, validates files, and keeps restore guidance visible.
 - [Codex TUI Proof](https://github.com/bnc4vk/codex-tui-proof) - Visually validate real local terminal UIs in Codex's in-app browser with screenshots and session evidence.
 - [Commit Narrator](./plugins/mturac/commit-narrator) - Generate semantic commit message from staged diff, including the _why_.
 - [debt-ops](https://github.com/bcanfield/agentic-tech-debt) - Catches AI-introduced tech debt at write-time: hooks log every deferral to a registry in your repo and a review skill ranks paydown by file churn.


### PR DESCRIPTION
Adds Codex Skin Pack Installer to Development & Workflow.

Why it fits:
- It is packaged as a Codex plugin with `.codex-plugin/plugin.json` and a standard `skills/` directory.
- It stages verified public-safe Codex desktop skin packs from GitHub Releases, validates files, and keeps restore guidance visible.
- It does not require API keys, OAuth, private screenshots, MCP servers, or app-bundle patching.

Scanner evidence:
- Local HOL Plugin Scanner v2.0.1015: Final Score 97/100, no critical/high/medium/low findings.
- Repo CI passing on latest main: https://github.com/ChannelerH/codex-skin-packs/actions/runs/29827171626

Plugin repo:
https://github.com/ChannelerH/codex-skin-packs
