### PR TITLE
Add Delx Recovery (agent recovery/continuity plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Cover My Repo](https://github.com/sjh9714/cover-my-repo) - Designs three checked GitHub social preview cards with Codex or Cursor, then renders them locally with Chrome.
 - [debt-ops](https://github.com/bcanfield/agentic-tech-debt) - Catches AI-introduced tech debt at write-time: hooks log every deferral to a registry in your repo and a review skill ranks paydown by file churn.
 - [Deps Doctor](./plugins/mturac/deps-doctor) - Multi-ecosystem dependency audit (npm, pip, cargo, go) in one report.
+- [Delx Recovery](https://github.com/davidmosiah/delx-plugins) - Free recovery and continuity plugin for AI agents: resume prior sessions, capture state, process failures into a recovery plan, and remember across sessions through a hosted MCP server (works in Codex, Claude Code, Cursor, and VS Code).
 - [Dely](https://github.com/hieuphung97/dely) - Multi-harness control protocol that turns requests into approved design contracts, orchestrating isolated worker sessions for sequential implementation and independent code reviews under Orca supervision for Claude Code, Codex, Cursor, Antigravity, and other AI coding agents.
 - [Designer Skill](https://github.com/Pythoughts-labs/designer-skill) - Plug-and-play MCP that gives your agent UI superpowers. One install: design skill + MCP server, zero config.
 - [Dev Skills](https://github.com/Jason-chen-coder/dev-skills) - Team workflow skills for specs, plans, TDD, debugging, verification, review, branch finishing, and design context.


### PR DESCRIPTION
## Plugin submission

- **Name:** Delx Recovery
- **Repository:** https://github.com/davidmosiah/delx-plugins
- **Category:** Cross-AI tools (Development & Workflow) — Agent Plugins 1.0.0 format + Claude Code and Codex flavors
- **What it does:** Free recovery and continuity for AI agents — resume prior sessions, capture state, process failures into a recovery plan, remember across sessions via a hosted MCP server (Streamable HTTP, no API key, no payment).
- **Works in:** Codex, Claude Code, Cursor, Copilot, VS Code (installed and verified from the public marketplace in Claude Code and Codex CLI).

## Scanner evidence (2026-08-15)

The listing gate asked for `hashgraph-online/ai-plugin-scanner-action` in `.github/workflows`. That is now on `main`:

- Workflow: https://github.com/davidmosiah/delx-plugins/blob/main/.github/workflows/plugin-scanner.yml
- Official action on push/PR: `hashgraph-online/ai-plugin-scanner-action@55616c962cf86368423f7673b2ecdfdbe613d1af` (`plugin_dir: "."`, `mode: scan`, `min_score: 80`, `fail_on_severity: high`)
- Passing CI after adding the official action: https://github.com/davidmosiah/delx-plugins/actions/runs/31904464512
- Local `plugin-scanner==2.0.1116` on repo root: **100/100 (A)**, `policy_pass=true`, critical/high **0**

Entry added alphabetically in Development & Workflow (before Deps Doctor), one-sentence description.
