### PR TITLE
Add dev-harness-kit to Development & Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Deps Doctor](./plugins/mturac/deps-doctor) - Multi-ecosystem dependency audit (npm, pip, cargo, go) in one report.
 - [Designer Skill](https://github.com/Pythoughts-labs/designer-skill) - Plug-and-play MCP that gives your agent UI superpowers. One install: design skill + MCP server, zero config.
 - [Dev Skills](https://github.com/Jason-chen-coder/dev-skills) - Team workflow skills for specs, plans, TDD, debugging, verification, review, branch finishing, and design context.
+- [dev-harness-kit](https://github.com/sh-ai-x/dev-harness-kit) - Enforced development workflow skills for Codex and Claude Code covering planning, TDD, debugging, review, security, CI, and release.
 - [Development Skills](https://github.com/reidemeister94/development-skills) - Three-tier triage (PASS_THROUGH / LIGHT / FULL 4-phase) development workflow for Codex and Claude Code with language auto-detection (Python, Java, TypeScript, Swift, frontend) and a staff-reviewer subagent for fresh-eyes review on every change.
 - [Ditto](https://github.com/ohad6k/ditto) - Mines selected evidence from local coding-agent sessions into private work, design, and writing profiles for Codex, Claude Code, and GitHub Copilot.
 - [Docflow](https://github.com/MedAdemBHA/docflow) - Lightweight documentation memory for AI coding agents that scaffolds a 7-category docs tree, runs readiness checks, validates docs before finishing, and keeps a monthly changelog across Claude Code and Codex.


### PR DESCRIPTION
## Plugin submission

- **Repository:** https://github.com/sh-ai-x/dev-harness-kit
- **Category:** Development & Workflow
- **What it does:** Enforced development workflow skills for Codex and Claude Code covering planning, TDD, debugging, review, security, CI, and release.
- **Entry:** Added alphabetically with a concise one-sentence description.

## Scanner evidence

- `uvx plugin-scanner lint . --format json` — `effective_score: 100/142`, `policy_pass: true`, and no findings.
- `uvx plugin-scanner verify . --format json` — `verify_pass: true`.
- Scanner CI runs on every push and pull request in [`plugin-scan.yml`](https://github.com/sh-ai-x/dev-harness-kit/blob/main/.github/workflows/plugin-scan.yml).
- `python3 scripts/check-alphabetical.py` — PASS.
- `git diff --check` — PASS.

The scanner-readiness fixes are tracked in [dev-harness-kit#620](https://github.com/sh-ai-x/dev-harness-kit/pull/620). This PR only adds one catalog entry to `README.md`; no plugin integration code is changed.
