### PR TITLE
Add Cargo to Tools & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) - Manage Bitbucket repos, PRs, branches, issues, webhooks, and pipelines for Data Center and Cloud.
 - [Call-E](https://github.com/CALLE-AI/call-e-integrations) - Plan, run, and inspect Call-E phone call workflows from Codex through the calle CLI.
 - [Canvas Apps Plugin Codex](https://github.com/Ratnam-Mishra/canvas-apps-plugin-codex) - Build and edit Microsoft Power Apps Canvas Apps using natural language and Canvas Authoring MCP server.
+- [Cargo](https://github.com/getcargohq/cargo-skills) - GTM engineering for coding agents — 17 skills over the Cargo CLI for lead sourcing, contact enrichment and email verification, lead scoring, CRM sync, buying-signal monitoring, and workspace-as-code.
 - [CarsXE](https://github.com/carsxe/carsxe-codex-plugin) - Decode VINs, license plates, market value, vehicle history, recalls, liens, OBD codes, and more via the CarsXE API.
 - [Chrome DevTools](https://github.com/win4r/chrome-devtools-codex-plugin) - One-click Codex plugin wrapper for chrome-devtools-mcp.
 - [claude-math](https://github.com/vladimirrott/claude-math) - Emit mathematics as copy- and search-safe inline Unicode (∑, ≤, ℝ, x², matrices, set-builder) instead of LaTeX so equations stay legible in the Codex TUI, terminals, and Claude Code.

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) - Manage Bitbucket repos, PRs, branches, issues, webhooks, and pipelines for Data Center and Cloud.
 - [Call-E](https://github.com/CALLE-AI/call-e-integrations) - Plan, run, and inspect Call-E phone call workflows from Codex through the calle CLI.
 - [Canvas Apps Plugin Codex](https://github.com/Ratnam-Mishra/canvas-apps-plugin-codex) - Build and edit Microsoft Power Apps Canvas Apps using natural language and Canvas Authoring MCP server.
-- [Cargo](https://github.com/getcargohq/cargo-skills) - GTM engineering for coding agents — 17 skills over the Cargo CLI for lead sourcing, contact enrichment and email verification, lead scoring, CRM sync, buying-signal monitoring, and workspace-as-code.
+- [Cargo Skills](https://github.com/getcargohq/cargo-skills) - GTM engineering for coding agents — 17 skills over the Cargo CLI for lead sourcing, contact enrichment and email verification, lead scoring, CRM sync, buying-signal monitoring, and workspace-as-code.
 - [CarsXE](https://github.com/carsxe/carsxe-codex-plugin) - Decode VINs, license plates, market value, vehicle history, recalls, liens, OBD codes, and more via the CarsXE API.
 - [Chrome DevTools](https://github.com/win4r/chrome-devtools-codex-plugin) - One-click Codex plugin wrapper for chrome-devtools-mcp.
 - [claude-math](https://github.com/vladimirrott/claude-math) - Emit mathematics as copy- and search-safe inline Unicode (∑, ≤, ℝ, x², matrices, set-builder) instead of LaTeX so equations stay legible in the Codex TUI, terminals, and Claude Code.


### PR DESCRIPTION
Adding **Cargo** to *Community Plugins → Tools & Integrations*, per the invitation in getcargohq/cargo-skills#83.

**Repository:** https://github.com/getcargohq/cargo-skills
**Category:** Community Plugins → Tools & Integrations (alphabetical, between *Canvas Apps Plugin Codex* and *CarsXE*)

### What it does

Seventeen agent skills that turn Claude Code, Codex, and Cursor into a go-to-market engineering workstation: build lead lists, find and verify emails and phone numbers, enrich companies and contacts through provider waterfalls, score leads, sync to a CRM, and monitor buying signals (job changes, funding, tech-stack and hiring intent) — plus workspace-as-code via a CDK.

It ships native manifests for three targets from one repo (`.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, and skills.sh), and runs on the [`@cargo-ai/cli`](https://www.npmjs.com/package/@cargo-ai/cli) npm package against the Cargo platform.

### Verification

Actively maintained — the repo has a lint workflow (`skills-lint.yml`), routing evals, and a publish pipeline, all green on `main`; the plugin version is pinned in lockstep with the CLI it documents. The skills load and route in Claude Code and Codex via the bundled plugin manifests.

### A note on the CI requirement

`CONTRIBUTING.md` asks submitters to add `hashgraph-online/ai-plugin-scanner-action@v1` to their own repo's GitHub Actions. We don't add third-party actions to that repo's CI — it ships an approval hook and publishes a package, so we keep its workflow surface to things we maintain.

That shouldn't block scoring: the *Plugin Trust Scores* section notes the HOL Registry already ingests every listed plugin and runs `plugin-scanner` against it server-side, so the score is produced either way. The repo is public and cloneable if a maintainer wants to run `plugin-scanner lint`/`verify` directly. Happy to address any findings it surfaces.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
