### PR TITLE
Add agent-talk

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Agent Guard](https://github.com/JeongJaeSoon/agent-guard) - Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI.
 - [Agent Harness Skills](https://github.com/yfge/agent-harness-skills) - Designs agent-ready repository harnesses with entrypoints, validation surfaces, runtime evidence, delivery records, and atomic commit guidance.
 - [Agent Workflow System](https://github.com/1139030773-cmd/agent-workflow-system) - 一套中文AI工作流系统：7个协作技能 + 行为规范宪法 + 会话恢复机制，模糊目标→可执行任务，全生命周期引导。Codex & Claude Code 双平台，新手友好。
+- [agent-talk](https://github.com/xhluca/agent-talk) - Skills-based plugin built on the retalk CLI that gives coding agents end-to-end encrypted messaging with other agents, including agents run by other people, across Claude Code, Codex, Antigravity, pi, opencode, and GitHub Copilot CLI.
 - [Agentic Ship](https://github.com/moasq/agentic-ship) - Cross-host product-development toolkit for Claude Code, Codex, Cursor, Hermes, and OpenClaw with shared rules, specialist roles, service connections, and machine-checked UI, backend, security, and launch gates.
 - [Agentizer](https://github.com/Humiris/wwa-transform) - Turn any website into an AI-powered agentfront with split-pane
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory that compounds between sessions.


### PR DESCRIPTION
## What

Adds a single entry for [agent-talk](https://github.com/xhluca/agent-talk) to the "Tools & Integrations" section of README.md, in alphabetical order. Submitted by invitation from this repo's maintainers, see xhluca/agent-talk#45.

## About agent-talk

agent-talk is a skills-based plugin built on the retalk CLI. It gives coding agents end-to-end encrypted messaging with other agents, including agents run by other people, so they can coordinate directly instead of a human relaying messages between windows. It installs under six agents: Claude Code, Codex, Antigravity, pi, opencode, and GitHub Copilot CLI. Source and docs: https://github.com/xhluca/agent-talk

## Category placement

The invitation described agent-talk as fitting "alongside the other mcp servers," but it is not an MCP server; it ships as Agent Skills through each host's own plugin system. This README doesn't have a dedicated "MCP servers" section — Community Plugins splits into "Development & Workflow" and "Tools & Integrations," and both already mix MCP servers, skills, and other plugin formats. I placed the entry in "Tools & Integrations," next to Agent Message Queue, the closest existing analog (also inter-agent messaging).

## Verification

Read through agent-talk's README.md and CONTRIBUTING.md to confirm the description above against the project's own stated scope and supported hosts.

## HOL Plugin Scanner gate (not completed)

CONTRIBUTING.md and SCANNER_GUIDE.md require a score of at least 80/142 from the HOL Plugin Scanner, with no critical/high findings, and a CI workflow running `hashgraph-online/ai-plugin-scanner-action` in the plugin's own repository. I did not run the scanner — it would mean executing a third-party PyPI package I have not vetted — and did not add the CI workflow, since that would require changes inside the agent-talk repository, which is out of scope for this PR. If a maintainer needs either before merging, please flag it and the repository owner can follow up separately.

## Disclosure

This pull request was written by Claude, an AI coding agent, on behalf of the repository owner (xhluca), who reviewed and approved the submission before it was opened.