### PR TITLE
fix(ci): publish open PR contribution checks

### DIFF
--- a/.github/workflows/sweep-open-prs.yml
+++ b/.github/workflows/sweep-open-prs.yml
@@ -27,6 +27,7 @@ jobs:
     outputs:
       matrix: ${{ steps.export.outputs.matrix }}
       has_failures: ${{ steps.export.outputs.has_failures }}
+      results: ${{ steps.export.outputs.results }}
     steps:
       - name: Check out validator
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -66,6 +67,7 @@ jobs:
         run: |
           echo "matrix=$(cat "$MATRIX_FILE")" >> "$GITHUB_OUTPUT"
           echo "has_failures=$(jq -r '.has_failures' "$STATUS_FILE")" >> "$GITHUB_OUTPUT"
+          echo "results=$(jq -c '.results' "$STATUS_FILE")" >> "$GITHUB_OUTPUT"
 
   scan:
     name: Scan PR #${{ matrix.contribution.pr_number }} source
@@ -117,3 +119,33 @@ jobs:
             exit 1
           fi
           echo "All checked open contributions satisfy the scanner gate."
+
+  publish:
+    name: Publish per-PR contribution checks
+    needs:
+      - discover
+      - scan
+      - gate
+    if: always() && github.event_name != 'pull_request_target'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - name: Check out validator
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+      - name: Publish checks on PR heads
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          OPEN_PR_RESULTS: ${{ needs.discover.outputs.results || '[]' }}
+          SWEEP_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: python3 scripts/publish-open-pr-checks.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,8 @@ severity thresholds above.
 Existing open pull requests are covered by the scheduled and manually
 dispatchable `.github/workflows/sweep-open-prs.yml` workflow. It reviews each
 PR's exact README base/head revisions without executing fork code, reports
-missing scanner CI, and runs the scanner for entries that pass the CI check.
+missing scanner CI, runs the scanner for entries that pass the CI check, and
+publishes the result on each PR head for scheduled/manual sweeps.
 
 Use scanner outputs as evidence for maintainers/reviewers:
 - Structural lint results

--- a/scripts/publish-open-pr-checks.py
+++ b/scripts/publish-open-pr-checks.py
@@ -146,6 +146,7 @@ def publish_check(
             "summary": f"PR #{number} — {title}\n\n{summary}",
         },
     }
+    update_payload = {key: value for key, value in payload.items() if key != "head_sha"}
 
     existing = github_api(
         repository,
@@ -157,7 +158,13 @@ def publish_check(
         item for item in check_runs if isinstance(item, dict) and item.get("name") == CHECK_NAME
     ]
     if matching and isinstance(matching[-1].get("id"), int):
-        github_api(repository, f"/check-runs/{matching[-1]['id']}", token, method="PATCH", payload=payload)
+        github_api(
+            repository,
+            f"/check-runs/{matching[-1]['id']}",
+            token,
+            method="PATCH",
+            payload=update_payload,
+        )
     else:
         github_api(repository, "/check-runs", token, method="POST", payload=payload)
     print(f"Published {CHECK_NAME} for PR #{number}: {conclusion}")

--- a/scripts/publish-open-pr-checks.py
+++ b/scripts/publish-open-pr-checks.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Publish the result of an open-PR sweep on each pull request head commit."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+API_ROOT = "https://api.github.com"
+CHECK_NAME = "Open Plugin Contribution Gate"
+USER_AGENT = "awesome-ai-plugins-open-pr-sweep"
+REQUEST_TIMEOUT_SECONDS = 30
+SCAN_JOB_RE = re.compile(r"Scan PR #(\d+) source")
+
+
+def github_api(repository: str, path: str, token: str, *, method: str = "GET", payload: object | None = None) -> object:
+    """Call the GitHub REST API with a bounded, JSON-only request."""
+
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "User-Agent": USER_AGENT,
+    }
+    data = None
+    if payload is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    request = Request(
+        f"{API_ROOT}/repos/{repository}{path}",
+        headers=headers,
+        method=method,
+        data=data,
+    )
+    try:
+        with urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except (HTTPError, URLError, TimeoutError, OSError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"GitHub API {method} {path} failed: {error}") from error
+
+
+def scan_conclusions(repository: str, run_id: str, token: str) -> dict[int, list[str]]:
+    """Return scanner job conclusions grouped by pull request number."""
+
+    conclusions: dict[int, list[str]] = {}
+    page = 1
+    while True:
+        payload = github_api(repository, f"/actions/runs/{run_id}/jobs?per_page=100&page={page}", token)
+        if not isinstance(payload, dict):
+            raise RuntimeError("GitHub returned an invalid jobs response")
+        jobs = payload.get("jobs")
+        if not isinstance(jobs, list):
+            raise RuntimeError("GitHub returned no jobs list")
+        for job in jobs:
+            if not isinstance(job, dict):
+                continue
+            name = job.get("name")
+            conclusion = job.get("conclusion")
+            if not isinstance(name, str) or not isinstance(conclusion, str):
+                continue
+            match = SCAN_JOB_RE.search(name)
+            if match:
+                conclusions.setdefault(int(match.group(1)), []).append(conclusion)
+        if len(jobs) < 100:
+            return conclusions
+        page += 1
+
+
+def check_summary(result: dict[str, object], scanner_jobs: dict[int, list[str]]) -> tuple[str, str, str]:
+    """Map validator/scan output to a check conclusion, title, and summary."""
+
+    number = result.get("pr_number")
+    state = result.get("state")
+    reasons = result.get("failure_reasons")
+    if not isinstance(number, int) or not isinstance(state, str):
+        raise RuntimeError("validator returned an invalid PR result")
+
+    if state == "success":
+        return (
+            "success",
+            "Contribution requirements passed",
+            "No new Community Plugins entries require validation in this pull request.",
+        )
+
+    if state == "failure":
+        failure_lines = reasons if isinstance(reasons, list) else []
+        details = "\n".join(f"- {item}" for item in failure_lines if isinstance(item, str))
+        return (
+            "failure",
+            "Contribution requirements failed",
+            "Required scanner CI is missing or could not be validated.\n\n" + details,
+        )
+
+    if state == "scan":
+        jobs = scanner_jobs.get(number, [])
+        if jobs and all(conclusion == "success" for conclusion in jobs):
+            return (
+                "success",
+                "Contribution scan passed",
+                f"All {len(jobs)} source-repository scanner job(s) passed the contribution gate.",
+            )
+        job_details = ", ".join(jobs) if jobs else "no scanner job was recorded"
+        return (
+            "failure",
+            "Contribution scan failed",
+            f"One or more source-repository scanner jobs did not pass: {job_details}.",
+        )
+
+    raise RuntimeError(f"unknown validator result state: {state}")
+
+
+def publish_check(
+    repository: str,
+    result: dict[str, object],
+    scanner_jobs: dict[int, list[str]],
+    run_url: str,
+    token: str,
+) -> None:
+    """Create or update the check run for one pull request head commit."""
+
+    head_sha = result.get("head_sha")
+    number = result.get("pr_number")
+    title = result.get("title")
+    if not isinstance(head_sha, str) or not re.fullmatch(r"[0-9a-fA-F]{40}", head_sha):
+        raise RuntimeError(f"PR #{number} has an invalid head SHA")
+    if not isinstance(number, int) or not isinstance(title, str):
+        raise RuntimeError("validator returned an invalid PR identity")
+
+    conclusion, check_title, summary = check_summary(result, scanner_jobs)
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    payload = {
+        "name": CHECK_NAME,
+        "head_sha": head_sha,
+        "status": "completed",
+        "conclusion": conclusion,
+        "started_at": now,
+        "completed_at": now,
+        "details_url": run_url,
+        "output": {
+            "title": check_title,
+            "summary": f"PR #{number} — {title}\n\n{summary}",
+        },
+    }
+
+    existing = github_api(
+        repository,
+        f"/commits/{quote(head_sha, safe='')}/check-runs?check_name={quote(CHECK_NAME)}&per_page=100",
+        token,
+    )
+    check_runs = existing.get("check_runs", []) if isinstance(existing, dict) else []
+    matching = [
+        item for item in check_runs if isinstance(item, dict) and item.get("name") == CHECK_NAME
+    ]
+    if matching and isinstance(matching[-1].get("id"), int):
+        github_api(repository, f"/check-runs/{matching[-1]['id']}", token, method="PATCH", payload=payload)
+    else:
+        github_api(repository, "/check-runs", token, method="POST", payload=payload)
+    print(f"Published {CHECK_NAME} for PR #{number}: {conclusion}")
+
+
+def main() -> int:
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    run_id = os.environ.get("GITHUB_RUN_ID", "").strip()
+    run_url = os.environ.get("SWEEP_RUN_URL", "").strip()
+    results_json = os.environ.get("OPEN_PR_RESULTS", "[]")
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+        print("ERROR: GITHUB_REPOSITORY must be an owner/repository pair", file=sys.stderr)
+        return 1
+    if not token or not run_id or not run_url:
+        print("ERROR: GITHUB_TOKEN, GITHUB_RUN_ID, and SWEEP_RUN_URL are required", file=sys.stderr)
+        return 1
+    try:
+        results = json.loads(results_json)
+        if not isinstance(results, list):
+            raise RuntimeError("OPEN_PR_RESULTS must be a JSON array")
+        scanner_jobs = scan_conclusions(repository, run_id, token)
+        for result in results:
+            if not isinstance(result, dict):
+                raise RuntimeError("validator returned a non-object PR result")
+            publish_check(repository, result, scanner_jobs, run_url, token)
+    except (RuntimeError, json.JSONDecodeError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate-contribution.py
+++ b/scripts/validate-contribution.py
@@ -445,6 +445,7 @@ def scan_open_pull_requests(
         "",
     ]
     failures: list[dict[str, object]] = []
+    results: list[dict[str, object]] = []
 
     for pull_request in pull_requests:
         prefix = f"PR #{pull_request.number} — {pull_request.title}"
@@ -452,14 +453,36 @@ def scan_open_pull_requests(
             entries = entries_for_open_pull_request(repository, pull_request)
         except ValidationError as error:
             failures.append({"pr_number": pull_request.number, "error": str(error)})
+            results.append(
+                {
+                    "pr_number": pull_request.number,
+                    "title": pull_request.title,
+                    "head_sha": pull_request.head_sha,
+                    "state": "failure",
+                    "contributions": [],
+                    "failure_reasons": [str(error)],
+                }
+            )
             report_lines.append(f"- **{prefix}: FAIL** — {error}")
             continue
 
         if not entries:
+            results.append(
+                {
+                    "pr_number": pull_request.number,
+                    "title": pull_request.title,
+                    "head_sha": pull_request.head_sha,
+                    "state": "success",
+                    "contributions": [],
+                    "failure_reasons": [],
+                }
+            )
             report_lines.append(f"- **{prefix}: PASS** — no new Community Plugins entries")
             continue
 
         report_lines.append(f"- **{prefix}**")
+        scanner_contributions: list[dict[str, str]] = []
+        scanner_failures: list[str] = []
         for entry in entries:
             contribution = f"{entry.owner}/{entry.repo}"
             try:
@@ -472,9 +495,11 @@ def scan_open_pull_requests(
                         "error": str(error),
                     }
                 )
+                scanner_failures.append(f"{contribution}: {error}")
                 report_lines.append(f"  - `{contribution}`: **FAIL** — {error}")
                 continue
 
+            scanner_contributions.append({"owner": entry.owner, "repo": entry.repo})
             matrix.append(
                 {
                     "pr_number": pull_request.number,
@@ -483,6 +508,17 @@ def scan_open_pull_requests(
                 }
             )
             report_lines.append(f"  - `{contribution}`: scanner CI present; queued for score scan")
+
+        results.append(
+            {
+                "pr_number": pull_request.number,
+                "title": pull_request.title,
+                "head_sha": pull_request.head_sha,
+                "state": "failure" if scanner_failures else "scan",
+                "contributions": scanner_contributions,
+                "failure_reasons": scanner_failures,
+            }
+        )
 
     if not pull_requests:
         report_lines.append("No open pull requests found.")
@@ -507,7 +543,14 @@ def scan_open_pull_requests(
     if status_output:
         status_output.parent.mkdir(parents=True, exist_ok=True)
         status_output.write_text(
-            json.dumps({"has_failures": bool(failures), "failures": failures}, separators=(",", ":")),
+            json.dumps(
+                {
+                    "has_failures": bool(failures),
+                    "failures": failures,
+                    "results": results,
+                },
+                separators=(",", ":"),
+            ),
             encoding="utf-8",
         )
 


### PR DESCRIPTION
## Summary
- Publish an `Open Plugin Contribution Gate` check on each open pull request head during scheduled or manual sweeps.
- Preserve per-PR validator results and combine them with source-repository scanner job conclusions.
- Document that scheduled/manual sweeps now publish results directly on pull requests.

## Testing
- `python3 -m py_compile scripts/validate-contribution.py scripts/publish-open-pr-checks.py`
- `actionlint .github/workflows/validate-contribution.yml .github/workflows/sweep-open-prs.yml`
- `git diff --check`
- Mocked validator-result and check-publisher cases
