### PR TITLE
fix(ci): allow PR remediation comments

### DIFF
--- a/.github/workflows/sweep-open-prs.yml
+++ b/.github/workflows/sweep-open-prs.yml
@@ -132,7 +132,7 @@ jobs:
       contents: read
       checks: write
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Check out validator
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/scripts/publish-open-pr-checks.py
+++ b/scripts/publish-open-pr-checks.py
@@ -42,7 +42,11 @@ def github_api(repository: str, path: str, token: str, *, method: str = "GET", p
     try:
         with urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
             return json.loads(response.read().decode("utf-8"))
-    except (HTTPError, URLError, TimeoutError, OSError, json.JSONDecodeError) as error:
+    except HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace").strip()
+        suffix = f": {detail}" if detail else ""
+        raise RuntimeError(f"GitHub API {method} {path} failed: HTTP {error.code}{suffix}") from error
+    except (URLError, TimeoutError, OSError, json.JSONDecodeError) as error:
         raise RuntimeError(f"GitHub API {method} {path} failed: {error}") from error
 
 


### PR DESCRIPTION
## Summary
- Grant the remediation publisher explicit pull-request write permission for PR comments.
- Include GitHub API error details when a write-back operation is rejected.

## Testing
- `python3 -m py_compile scripts/validate-contribution.py scripts/publish-open-pr-checks.py`
- `actionlint .github/workflows/validate-contribution.yml .github/workflows/sweep-open-prs.yml`
- `git diff --check`
