### PR TITLE
Add Dopamine agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Development Skills](https://github.com/reidemeister94/development-skills) - Three-tier triage (PASS_THROUGH / LIGHT / FULL 4-phase) development workflow for Codex and Claude Code with language auto-detection (Python, Java, TypeScript, Swift, frontend) and a staff-reviewer subagent for fresh-eyes review on every change.
 - [Ditto](https://github.com/ohad6k/ditto) - Mines selected evidence from local coding-agent sessions into private work, design, and writing profiles for Codex, Claude Code, and GitHub Copilot.
 - [Docflow](https://github.com/MedAdemBHA/docflow) - Lightweight documentation memory for AI coding agents that scaffolds a 7-category docs tree, runs readiness checks, validates docs before finishing, and keeps a monthly changelog across Claude Code and Codex.
+- [Dopamine](https://github.com/ujjwalredd/Dopamine) - Cross-agent skill for adaptive effort, minimal complete changes, and evidence-based stop conditions, with reproducible efficiency benchmarks and adapters for 24 agents.
 - [ejentum-mcp](https://github.com/ejentum/ejentum-mcp) - MCP server exposing reasoning, code, anti-deception, and memory harness tools for Codex.
 - [Env Lint](./plugins/mturac/env-lint) - `.env` vs `.env.example` key parity — never prints values.
 - [Epic Harness](https://github.com/epicsagas/epic-harness) - Auto-trigger quality skills + self-evolving agent harness — orbit (spec-to-ship), evolve (skill mutation), team (multi-agent), TDD, check, ship, simplify, debug, perf, secure.


### PR DESCRIPTION
## Description

Adds Dopamine to **Community Plugins → Development & Workflow**. Dopamine is a cross-agent skill for adaptive effort, minimal complete changes, and evidence-based stop conditions, with reproducible efficiency benchmarks and adapters for 24 agents.

Repository: https://github.com/ujjwalredd/Dopamine

## Verification

- HOL Plugin Security Scan passed the required score/severity gate: https://github.com/ujjwalredd/Dopamine/actions/runs/31761966213
- `plugin-scanner lint .` passed locally.
- `plugin-scanner verify .` passed locally.
- Catalog contribution validator confirmed the required push/PR-triggered scanner CI.
- Dopamine test suite: 18/18 passing.
- Entry is one sentence and alphabetically placed.