### PR TITLE
docs: explain scanner trust and listing benefits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,12 @@ Thank you for considering a contribution!
    ```
 4. **Add to appropriate section** - Codex plugins, Claude Code skills, Gemini extensions, MCP servers, or Cross-AI tools
 
+## What an accepted listing provides
+
+Accepted extensions can be indexed in the [HOL Plugin Registry](https://hol.org/registry/plugins), where they receive a dedicated public profile with trust signals and links to the project.
+
+The registry profile includes a standard **dofollow backlink** to the extension's repository or homepage. This gives search engines a crawlable reference from HOL and may improve discovery and SEO, although no search ranking is guaranteed.
+
 ## Validation
 
 Before submitting:
@@ -33,6 +39,31 @@ All plugins submitted to **Awesome AI Plugins** must pass the HOL AI Plugin Scan
 | **CI** | Scanner must run in your repo's GitHub Actions |
 
 See the full guide: [`SCANNER_GUIDE.md`](./SCANNER_GUIDE.md)
+
+### Why scanner CI is required
+
+AI extensions can register hooks, execute commands, read environment variables, and influence an agent's behavior. A compromised extension can therefore affect users outside the original repository. Scanner CI gives every community listing the same reproducible baseline for identifying:
+
+- committed secrets and unsafe credential handling;
+- dangerous hooks or command execution;
+- overly broad GitHub Actions permissions;
+- unpinned third-party actions and dependencies;
+- malformed or misleading extension metadata.
+
+A passing scan is not a guarantee that an extension is harmless. It is reviewable evidence that every listed project cleared the same minimum checks, which helps maintainers catch common supply-chain risks before users install the extension.
+
+### What the scanner workflow can access
+
+The recommended workflow:
+
+- grants only `contents: read`;
+- does not require repository secrets or write permissions;
+- keeps live network probing disabled by default;
+- installs a fixed scanner release;
+- verifies the scanner wheel's SHA-256 and PyPI provenance;
+- uploads SARIF only when the maintainer explicitly enables it.
+
+The example in [`SCANNER_GUIDE.md`](./SCANNER_GUIDE.md) pins GitHub Actions to immutable commit SHAs so a mutable tag cannot silently change the code executed by the workflow.
 
 Pull requests that add a Community Plugin entry are checked automatically by
 `.github/workflows/validate-contribution.yml`. The check confirms that the

--- a/SCANNER_GUIDE.md
+++ b/SCANNER_GUIDE.md
@@ -58,16 +58,34 @@ The scanner checks 7 categories totaling 142 points:
 ```yaml
 name: Plugin Security Scan
 on: [pull_request, push]
+permissions:
+  contents: read
 jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: hashgraph-online/ai-plugin-scanner-action@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: hashgraph-online/ai-plugin-scanner-action@55616c962cf86368423f7673b2ecdfdbe613d1af # v1.2.515
         with:
           plugin_dir: "."
+          min_score: 80
           fail_on_severity: high
 ```
+
+### Supply-chain properties
+
+The recommended workflow is intentionally constrained:
+
+- `contents: read` is the only GitHub permission;
+- no repository secrets are required;
+- checkout credentials are not persisted;
+- online probing and SARIF upload are disabled unless explicitly enabled;
+- the scanner action and its dependencies are pinned;
+- the scanner wheel is checked against a committed SHA-256 and verified PyPI provenance before installation.
+
+Review the [action source](https://github.com/hashgraph-online/ai-plugin-scanner-action) and pinned commit before enabling it. A passing result is a consistent baseline for community review, not a claim that software is risk-free.
 
 ### Required for Awesome AI Plugins listing
 


### PR DESCRIPTION
## Summary

- explain the scanner requirement in supply-chain terms
- document read-only permissions, immutable action pins, wheel hash, and PyPI provenance verification
- document HOL registry profiles and their dofollow backlink benefit
- replace mutable workflow tags with reviewed commit SHAs

## Verification

- documentation diff passes git diff --check
- scanner claims verified against the current action definition and contribution workflow