### PR TITLE
ci: sync scanner action commit pins

### DIFF
--- a/.github/workflows/sync-scanner-action.yml
+++ b/.github/workflows/sync-scanner-action.yml
@@ -1,0 +1,47 @@
+name: Sync Scanner Action
+
+on:
+  schedule:
+    # Match the HOL Guard scanner release cadence without polling excessively.
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: Sync scanner action commit pins
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Test scanner action sync
+        env:
+          PYTHONDONTWRITEBYTECODE: "1"
+        run: python3 -m unittest tests/test-sync-scanner-action.py
+
+      - name: Sync scanner action
+        id: sync
+        run: |
+          python3 scripts/sync-scanner-action.py
+          if git diff --quiet -- CONTRIBUTING.md SCANNER_GUIDE.md .github/workflows/validate-contribution.yml .github/workflows/sweep-open-prs.yml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Scanner action pins are already up to date"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git diff --stat -- CONTRIBUTING.md SCANNER_GUIDE.md .github/workflows/validate-contribution.yml .github/workflows/sweep-open-prs.yml
+          fi
+
+      - name: Commit and push
+        if: steps.sync.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CONTRIBUTING.md SCANNER_GUIDE.md .github/workflows/validate-contribution.yml .github/workflows/sweep-open-prs.yml
+          git commit -m "chore: sync scanner action commit pin"
+          git push

--- a/scripts/sync-scanner-action.py
+++ b/scripts/sync-scanner-action.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Pin documented AI Plugin Scanner Action uses to the latest release commit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ACTION_REPOSITORY = "hashgraph-online/ai-plugin-scanner-action"
+API_ROOT = f"https://api.github.com/repos/{ACTION_REPOSITORY}"
+USER_AGENT = "awesome-ai-plugins-action-sync"
+REQUEST_TIMEOUT_SECONDS = 30
+PINNED_FILES = (
+    REPO_ROOT / "CONTRIBUTING.md",
+    REPO_ROOT / "SCANNER_GUIDE.md",
+    REPO_ROOT / ".github/workflows/validate-contribution.yml",
+    REPO_ROOT / ".github/workflows/sweep-open-prs.yml",
+)
+ACTION_PATTERN = re.compile(
+    r"(hashgraph-online/ai-plugin-scanner-action@)([0-9a-f]{40})"
+    r"(?:\s+#\s+(v\d+\.\d+\.\d+))?"
+)
+
+
+def fetch_json(url: str) -> dict[str, Any]:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+        return json.loads(response.read())
+
+
+def resolve_commit(obj: dict[str, Any]) -> str:
+    """Resolve a GitHub ref object, following annotated tags when necessary."""
+    for _ in range(5):
+        object_type = obj.get("type")
+        sha = obj.get("sha")
+        if object_type == "commit" and isinstance(sha, str) and re.fullmatch(
+            r"[0-9a-f]{40}", sha
+        ):
+            return sha
+        if object_type != "tag" or not isinstance(sha, str):
+            break
+        obj = fetch_json(f"{API_ROOT}/git/tags/{sha}")["object"]
+    raise RuntimeError("Latest scanner action release did not resolve to a commit")
+
+
+def fetch_latest_release() -> tuple[str, str]:
+    release = fetch_json(f"{API_ROOT}/releases/latest")
+    version = release.get("tag_name")
+    if not isinstance(version, str) or not re.fullmatch(r"v\d+\.\d+\.\d+", version):
+        raise RuntimeError("Latest scanner action release has an invalid tag")
+
+    ref = fetch_json(f"{API_ROOT}/git/ref/tags/{version}")
+    return version, resolve_commit(ref["object"])
+
+
+def update_files(version: str, commit: str, *, check: bool) -> list[Path]:
+    matches: list[tuple[Path, re.Match[str]]] = []
+    contents: dict[Path, str] = {}
+    for path in PINNED_FILES:
+        content = path.read_text(encoding="utf-8")
+        contents[path] = content
+        matches.extend((path, match) for match in ACTION_PATTERN.finditer(content))
+
+    if not matches:
+        raise RuntimeError("No pinned scanner action uses were found")
+
+    current_commits = {match.group(2) for _, match in matches}
+    if len(current_commits) != 1:
+        raise RuntimeError("Existing scanner action pins are inconsistent")
+
+    replacement = rf"\g<1>{commit} # {version}"
+    changed: list[Path] = []
+    for path, content in contents.items():
+        updated = ACTION_PATTERN.sub(replacement, content)
+        if updated == content:
+            continue
+        changed.append(path)
+        if not check:
+            path.write_text(updated, encoding="utf-8")
+    return changed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="Report drift only")
+    args = parser.parse_args()
+
+    try:
+        version, commit = fetch_latest_release()
+        changed = update_files(version, commit, check=args.check)
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if changed:
+        print("DRIFT" if args.check else f"Updated scanner action to {version} ({commit})")
+        for path in changed:
+            print(f"  {path.relative_to(REPO_ROOT)}")
+    else:
+        print(f"OK: scanner action is {version} ({commit})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test-sync-scanner-action.py
+++ b/tests/test-sync-scanner-action.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts/sync-scanner-action.py"
+SPEC = importlib.util.spec_from_file_location("sync_scanner_action", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class SyncScannerActionTests(unittest.TestCase):
+    def test_resolve_commit_follows_annotated_tag(self) -> None:
+        commit = "b" * 40
+        with patch.object(
+            MODULE,
+            "fetch_json",
+            return_value={"object": {"type": "commit", "sha": commit}},
+        ):
+            self.assertEqual(
+                MODULE.resolve_commit({"type": "tag", "sha": "a" * 40}),
+                commit,
+            )
+
+    def test_update_files_replaces_all_consistent_pins(self) -> None:
+        old_commit = "a" * 40
+        new_commit = "b" * 40
+        with tempfile.TemporaryDirectory() as directory:
+            paths = [Path(directory) / f"file-{index}.yml" for index in range(2)]
+            for path in paths:
+                path.write_text(
+                    f"uses: hashgraph-online/ai-plugin-scanner-action@{old_commit} # v1.0.0\n"
+                )
+            with patch.object(MODULE, "PINNED_FILES", tuple(paths)):
+                changed = MODULE.update_files("v1.1.0", new_commit, check=False)
+
+            self.assertEqual(changed, paths)
+            for path in paths:
+                self.assertIn(f"@{new_commit} # v1.1.0", path.read_text())
+
+    def test_update_files_is_noop_when_current(self) -> None:
+        commit = "b" * 40
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "workflow.yml"
+            path.write_text(
+                f"uses: hashgraph-online/ai-plugin-scanner-action@{commit} # v1.1.0\n"
+            )
+            with patch.object(MODULE, "PINNED_FILES", (path,)):
+                self.assertEqual(MODULE.update_files("v1.1.0", commit, check=False), [])
+
+    def test_update_files_rejects_inconsistent_existing_pins(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            paths = [Path(directory) / f"file-{index}.yml" for index in range(2)]
+            paths[0].write_text(
+                f"uses: hashgraph-online/ai-plugin-scanner-action@{'a' * 40}\n"
+            )
+            paths[1].write_text(
+                f"uses: hashgraph-online/ai-plugin-scanner-action@{'b' * 40}\n"
+            )
+            with patch.object(MODULE, "PINNED_FILES", tuple(paths)):
+                with self.assertRaisesRegex(RuntimeError, "inconsistent"):
+                    MODULE.update_files("v1.1.0", "c" * 40, check=False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- poll the latest AI Plugin Scanner Action release every six hours
- resolve its release tag to an immutable commit and update all maintained pins atomically
- test annotated tags, replacements, no-op runs, and inconsistent pin rejection

## Verification
- `actionlint .github/workflows/sync-scanner-action.yml`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests/test-sync-scanner-action.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 scripts/sync-scanner-action.py --check`
- `git diff --check`