### PR TITLE
ci: update scanner sync runtime actions

### DIFF
--- a/.github/workflows/sync-scanner-action.yml
+++ b/.github/workflows/sync-scanner-action.yml
@@ -14,9 +14,9 @@ jobs:
     name: Sync scanner action commit pins
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Summary
- update the scanner pin sync workflow to current immutable checkout and setup-python releases
- remove the Node 20 deprecation warning observed in the first live dispatch

## Verification
- `actionlint .github/workflows/sync-scanner-action.yml`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests/test-sync-scanner-action.py`
- `git diff --check`