### PR TITLE
Add Cadence Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [AutoCAD Tianzheng Tools](https://github.com/summer521521/AutoCAD_Tianzheng_plugin) - Connects Codex to AutoCAD and Tianzheng HVAC through a local MCP server for DWG-aware HVAC drawing inspection and workflow automation.
 - [AxonFlow](https://github.com/getaxonflow/axonflow-codex-plugin) - Runtime governance for Codex with policy enforcement on terminal commands, advisory checks for non-terminal tools via skills, PII/secret detection, and compliance-grade audit trails. Self-hosted via Docker.
 - [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) - Manage Bitbucket repos, PRs, branches, issues, webhooks, and pipelines for Data Center and Cloud.
+- [Cadence Code](https://github.com/michael-L-i/cadence-code) - Fully local voice conversations for Claude Code, Codex, Cursor, and Antigravity on Apple Silicon, with selectable MLX speech and transcription models.
 - [Call-E](https://github.com/CALLE-AI/call-e-integrations) - Plan, run, and inspect Call-E phone call workflows from Codex through the calle CLI.
 - [Canvas Apps Plugin Codex](https://github.com/Ratnam-Mishra/canvas-apps-plugin-codex) - Build and edit Microsoft Power Apps Canvas Apps using natural language and Canvas Authoring MCP server.
 - [CarsXE](https://github.com/carsxe/carsxe-codex-plugin) - Decode VINs, license plates, market value, vehicle history, recalls, liens, OBD codes, and more via the CarsXE API.


### PR DESCRIPTION
Adding [Cadence Code](https://github.com/michael-L-i/cadence-code), following up on the invitation in michael-L-i/cadence-code#53.

## What it does

Cadence Code gives coding agents a fully local voice interface on Apple Silicon.
A stdio MCP server owns the selected TTS and STT models directly, so speech
input and output run entirely on device through MLX Audio. There is no HTTP
daemon, no cloud speech service, and no second language model rewriting the
agent's responses. Users pick their own speech and transcription models.

Supported hosts: Claude Code, Codex, Cursor, and Antigravity.

## Category

Community Plugins -> Tools & Integrations, inserted alphabetically between
`Bitbucket CLI` and `Call-E`. `scripts/check-alphabetical.py` passes locally.

## Scanner results

Scanner CI runs on push and pull_request in the source repository:
`.github/workflows/plugin-scanner.yml`, using
`hashgraph-online/ai-plugin-scanner-action` pinned to `55616c9` (v1.2.515)
with `min_score: 80` and `fail_on_severity: high`.

Latest run on the default branch:

| Check | Result |
|---|---|
| Score | 97/100 (A - Excellent) |
| Critical / high / medium / low findings | 0 / 0 / 0 / 0 |
| Info findings | 9 |
| `plugin-scanner verify` | pass, 16/16 cases |

## Verification

- Full unit suite green, 101 tests, across macOS 14/15/26 and Python 3.11-3.14.
- `scripts/validate_plugin.py` confirms the plugin manifests match the release.
- Latest release: Cadence Code 0.6.0. Repository is public and actively maintained.