### PR TITLE
Add Agent Guild

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Agency Continuity Audit](https://github.com/revertcreations/agency-continuity-audit) - Read-only audit that distinguishes durable agent goals, state, corrections, restart evidence, authority boundaries, scheduler claims, and commercial proof from self-reported health.
 - [Agent Deck](https://github.com/not-so-fat/agent-deck) - One MCP for context management: bind self-improving playbooks, MCP tools, and API keys to the session.
 - [Agent Guard](https://github.com/JeongJaeSoon/agent-guard) - Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI.
+- [Agent Guild](https://github.com/AgentTanuki/agent-guild-plugin) - Vet autonomous agents before delegating work or money, verify portable passports, use escrow, and record signed outcomes across Claude Code, Codex, MCP, A2A, and OpenClaw.
 - [Agent Harness Skills](https://github.com/yfge/agent-harness-skills) - Designs agent-ready repository harnesses with entrypoints, validation surfaces, runtime evidence, delivery records, and atomic commit guidance.
 - [Agent Workflow System](https://github.com/1139030773-cmd/agent-workflow-system) - 一套中文AI工作流系统：7个协作技能 + 行为规范宪法 + 会话恢复机制，模糊目标→可执行任务，全生命周期引导。Codex & Claude Code 双平台，新手友好。
 - [Agentizer](https://github.com/Humiris/wwa-transform) - Turn any website into an AI-powered agentfront with split-pane


### PR DESCRIPTION
## What this adds

Adds [Agent Guild](https://github.com/AgentTanuki/agent-guild-plugin) to **Development & Workflow**.

Agent Guild is a dual Claude Code and Codex plugin for vetting autonomous agents before delegation or payment, verifying portable Agent Passports, using escrow, and recording signed collaboration outcomes. It also exposes its public trust service over MCP and works with A2A/OpenClaw discovery surfaces.

## Verification

- Repository-root plugin and skill validators pass.
- HOL Plugin Scanner: **98/100 (A)**.
- Scanner policy and runtime verification: **PASS**.
- Findings: **0 critical, 0 high, 0 medium, 0 low**.
- Scanner runs in the source repository via a least-privilege workflow with actions pinned to immutable SHAs: https://github.com/AgentTanuki/agent-guild-plugin/actions/workflows/plugin-security.yml
- `python3 scripts/check-alphabetical.py README.md` passes.

The release repository is intentionally scanner-clean and contains the same audited plugin package published from the canonical service repository.