### PR TITLE
feat: add DeepSeek Harness catalog support

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
   "source": "awesome-ai-plugins",
-  "last_updated": "2026-08-16T15:23:24.347370+00:00",
+  "last_updated": "2026-08-16",
   "plugins": [
     {
       "name": "Registry Broker",

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
   "source": "awesome-ai-plugins",
-  "last_updated": "2026-08-16T15:21:36.908831+00:00",
+  "last_updated": "2026-08-16T15:23:24.347370+00:00",
   "plugins": [
     {
       "name": "Registry Broker",

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
   "source": "awesome-ai-plugins",
-  "last_updated": "2026-08-16T11:02:52.264523+00:00",
+  "last_updated": "2026-08-16T15:16:53.696703+00:00",
   "plugins": [
     {
       "name": "Registry Broker",
@@ -678,6 +678,21 @@
       "repo": "agentic-tech-debt",
       "url": "https://github.com/bcanfield/agentic-tech-debt",
       "install_url": "https://raw.githubusercontent.com/bcanfield/agentic-tech-debt/HEAD/codex/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "DeepSeek Mini-Router",
+      "displayName": "DeepSeek Mini-Router",
+      "description": "Task-aware spec/react/flash working-contract plugin that fixes DeepSeek weak default reasoning inside Codex, with a measured BigCodeBench harness included.",
+      "category": "Development & Workflow",
+      "source": "awesome-ai-plugins",
+      "platform": "codex",
+      "ecosystems": [
+        "codex"
+      ],
+      "owner": "hccccc01333",
+      "repo": "codex-deepseek-mini-router",
+      "url": "https://github.com/hccccc01333/codex-deepseek-mini-router",
+      "install_url": "https://raw.githubusercontent.com/hccccc01333/codex-deepseek-mini-router/HEAD/.codex-plugin/plugin.json"
     },
     {
       "name": "Designer Skill",

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
   "source": "awesome-ai-plugins",
-  "last_updated": "2026-08-16T15:16:53.696703+00:00",
+  "last_updated": "2026-08-16T15:21:36.908831+00:00",
   "plugins": [
     {
       "name": "Registry Broker",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,15 @@ Thank you for considering a contribution!
    ```
    - [Extension Name](https://github.com/owner/repo) - Description (max 1 sentence).
    ```
-4. **Add to appropriate section** - Codex plugins, Claude Code skills, Gemini extensions, MCP servers, or Cross-AI tools
+4. **Add to appropriate section** - Codex plugins, Claude Code skills, Gemini extensions, DeepSeek Harness plugins, MCP servers, or Cross-AI tools
+
+### DeepSeek Harness submissions
+
+DeepSeek Harness (DSH) plugins are Cordis modules or npm packages. A listed
+package must expose an `apply(ctx)` plugin entry point and declare an installable
+`dsh.bundle` in `package.json`; a Codex `.codex-plugin/plugin.json` manifest is
+not required. Use the exact GitHub repository URL in the README and document the
+package name or `dsh plugin add` command in that repository's README.
 
 ## What an accepted listing provides
 
@@ -65,7 +73,8 @@ The recommended workflow:
 
 The example in [`SCANNER_GUIDE.md`](./SCANNER_GUIDE.md) pins GitHub Actions to immutable commit SHAs so a mutable tag cannot silently change the code executed by the workflow.
 
-Pull requests that add a Community Plugin entry are checked automatically by
+Pull requests that add a Community Plugin entry, including the DeepSeek Harness
+Plugins subsection, are checked automatically by
 `.github/workflows/validate-contribution.yml`. The check confirms that the
 linked public repository runs `hashgraph-online/ai-plugin-scanner-action` from
 GitHub Actions, then scans the contributed repository with the same score and

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 </p>
 
 <p align="center">
-  Discover extensions for Codex, ChatGPT, Claude Code, Gemini CLI, Cursor, OpenCode, and other compatible AI assistants from one community-maintained catalog.
+  Discover extensions for Codex, ChatGPT, Claude Code, Gemini CLI, DeepSeek Harness, Cursor, OpenCode, and other compatible AI assistants from one community-maintained catalog.
 </p>
 
 <p align="center">
@@ -36,6 +36,7 @@
 - [Start Here](#start-here)
 - [Official Plugins](#official-plugins)
 - [Community Plugins](#community-plugins)
+  - [DeepSeek Harness Plugins](#deepseek-harness-plugins)
 - [Formats & Development](#formats--development)
 - [Guides & Articles](#guides--articles)
 - [Related Projects](#related-projects)
@@ -330,9 +331,18 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Yandex Direct](https://github.com/nebelov/yandex-direct-for-all) - GitHub-ready Codex plugin bundle for Yandex Direct, Wordstat, Metrika, and Roistat.
 - [Zotero Research Tools](https://github.com/summer521521/Zotero_Research_plugin) - Connects Codex to Zotero Desktop for local-library search, citation export, collection and tag inspection, and research workflow support.
 
+### DeepSeek Harness Plugins
+
+DeepSeek Harness (DSH) plugins are Cordis modules or npm packages that expose a
+`dsh.bundle` manifest and can be installed with `dsh plugin add`. Add verified
+community plugins here in alphabetical order. See the [official DeepSeek Harness
+plugin tutorial](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/cordis-tutorial/01-first-plugin.md)
+and the [`dsh-plugin` community topic](https://github.com/topics/dsh-plugin) before
+submitting a repository.
+
 ## Formats & Development
 
-AI extensions use several overlapping formats. Agent Skills provide reusable instructions, MCP servers expose tools and data, and client-specific plugin manifests package those capabilities for installation. Prefer open formats where practical, then add client adapters for the assistants you support.
+AI extensions use several overlapping formats. Agent Skills provide reusable instructions, MCP servers expose tools and data, DeepSeek Harness loads Cordis modules/npm packages, and client-specific plugin manifests package those capabilities for installation. Prefer open formats where practical, then add client adapters for the assistants you support.
 
 ### Getting Started
 
@@ -353,6 +363,28 @@ my-plugin/
 │       └── references/       # Optional: docs and templates
 ├── apps/                     # Optional: app integrations
 └── mcp.json                  # Optional: MCP server configuration
+```
+
+### DeepSeek Harness Plugin Anatomy
+
+DeepSeek Harness plugins export a Cordis `apply` function. Installable packages
+declare a `dsh.bundle` entry in `package.json`; they do not need a
+`.codex-plugin/plugin.json` file.
+
+```ts
+import type { Context } from '@deepseek-ai/cordis'
+
+export const name = 'my-plugin'
+
+export function apply(ctx: Context) {
+  // Register services, tools, or UI contributions with ctx.
+}
+```
+
+Install a published package or GitHub package through the DSH profile manager:
+
+```bash
+dsh plugin add <npm-package-or-github-spec>
 ```
 
 ### Codex Plugin Creator
@@ -410,6 +442,7 @@ The score is best used as a quick trust signal and triage summary (not the only 
 
 ## Related Projects
 
+- [Awesome DeepSeek Harness Plugins](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) - Community-maintained DSH plugin list and discovery reference.
 - [awesome-codex-plugins](https://github.com/hashgraph-online/awesome-codex-plugins) - Codex-focused catalog that inspired this cross-platform list.
 - [HOL Plugin Registry](https://hol.org/registry/plugins) - Browse plugins with scanner-backed security analysis and trust scores.
 

--- a/SCANNER_GUIDE.md
+++ b/SCANNER_GUIDE.md
@@ -37,7 +37,9 @@ plugin-scanner verify /path/to/plugin --format text
 
 ## Scoring System
 
-The scanner checks 7 categories totaling 142 points:
+The scanner checks 7 categories totaling 142 points. For DeepSeek Harness
+packages, the scanner evaluates the repository and package surfaces even though
+the runtime uses Cordis and `dsh.bundle` rather than a Codex manifest:
 
 | Category | Points | Key Checks |
 |----------|--------|------------|
@@ -50,6 +52,14 @@ The scanner checks 7 categories totaling 142 points:
 | Code Quality | 10 | No TODOs, no debug code, consistent style |
 
 **Passing criteria:** Score ≥ 80/142, with no critical or high severity findings.
+
+### DeepSeek Harness package checks
+
+DeepSeek Harness plugins should keep the installable `dsh.bundle` declaration in
+`package.json`, export a Cordis `apply(ctx)` entry point, and document a tested
+`dsh plugin add <package-or-github-spec>` flow. The scanner CI gate remains the
+same for every ecosystem: score at least 80 and fail on high or critical
+findings.
 
 ## CI/CD Integration
 

--- a/plugins.json
+++ b/plugins.json
@@ -3,7 +3,7 @@
   "name": "awesome-ai-plugins",
   "version": "1.0.0",
   "last_updated": "2026-08-16",
-  "total": 206,
+  "total": 207,
   "platforms": [
     "codex",
     "grok"
@@ -635,6 +635,20 @@
       "category": "Development & Workflow",
       "source": "awesome-ai-plugins",
       "install_url": "https://raw.githubusercontent.com/bcanfield/agentic-tech-debt/HEAD/codex/.codex-plugin/plugin.json",
+      "platform": "codex",
+      "ecosystems": [
+        "codex"
+      ]
+    },
+    {
+      "name": "DeepSeek Mini-Router",
+      "url": "https://github.com/hccccc01333/codex-deepseek-mini-router",
+      "owner": "hccccc01333",
+      "repo": "codex-deepseek-mini-router",
+      "description": "Task-aware spec/react/flash working-contract plugin that fixes DeepSeek weak default reasoning inside Codex, with a measured BigCodeBench harness included.",
+      "category": "Development & Workflow",
+      "source": "awesome-ai-plugins",
+      "install_url": "https://raw.githubusercontent.com/hccccc01333/codex-deepseek-mini-router/HEAD/.codex-plugin/plugin.json",
       "platform": "codex",
       "ecosystems": [
         "codex"

--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -372,7 +372,10 @@ def generate_marketplace_json(plugins: list[dict]) -> dict:
     return {
         "schema_version": "1.0",
         "source": "awesome-ai-plugins",
-        "last_updated": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        # Keep regeneration deterministic within a day. A wall-clock
+        # timestamp would make the sync workflow commit on every run and
+        # retrigger itself indefinitely.
+        "last_updated": datetime.date.today().isoformat(),
         "plugins": plugins,
     }
 

--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -35,6 +35,15 @@ INSTALL_PATH_CANDIDATES = (
     ".codex/plugin.json",
 )
 INSTALL_URL_PROBE_TIMEOUT = 6.0
+DEEPSEEK_HARNESS_PLATFORM = "deepseek-harness"
+
+# Community entries live under one README section. Keep the platform attached
+# to each subsection so a DeepSeek Harness entry is not misclassified as a
+# Codex plugin merely because both catalogs share the same human-readable
+# section.
+COMMUNITY_CATEGORY_PLATFORMS = {
+    "DeepSeek Harness Plugins": DEEPSEEK_HARNESS_PLATFORM,
+}
 
 
 def probe_install_url(owner: str, repo: str) -> str | None:
@@ -192,6 +201,7 @@ PLATFORM_SECTIONS = {
     "OpenCode Plugins": "opencode",
     "Google Gemini CLI Plugins": "gemini-cli",
     "MCP Servers (Cross-Platform)": "mcp",
+    "DeepSeek Harness Plugins": DEEPSEEK_HARNESS_PLATFORM,
     # Current README structure: a single `## Community Plugins` section with
     # `###` subcategories. Treat its entries as codex marketplace plugins.
     "Community Plugins": "codex",
@@ -210,6 +220,7 @@ def parse_plugins(readme_path: Path) -> list[dict]:
 
     plugins: list[dict] = []
     current_platform: str | None = None
+    current_section = ""
     current_category = ""
 
     h2_re = re.compile(r"^##\s+(.+?)\s*$")
@@ -219,13 +230,19 @@ def parse_plugins(readme_path: Path) -> list[dict]:
     for line in content.split("\n"):
         h2 = h2_re.match(line)
         if h2:
-            current_platform = PLATFORM_SECTIONS.get(h2.group(1).strip())
+            current_section = h2.group(1).strip()
+            current_platform = PLATFORM_SECTIONS.get(current_section)
             current_category = ""
             continue
 
         h3 = h3_re.match(line.strip())
         if h3:
-            current_category = h3.group(1)
+            current_category = h3.group(1).strip()
+            if current_section == "Community Plugins":
+                current_platform = COMMUNITY_CATEGORY_PLATFORMS.get(
+                    current_category,
+                    PLATFORM_SECTIONS["Community Plugins"],
+                )
             continue
 
         item = item_re.match(line.strip())
@@ -246,7 +263,7 @@ def parse_plugins(readme_path: Path) -> list[dict]:
         owner = owner_match.group(1)
         repo = owner_match.group(2).removesuffix(".git")
 
-        plugins.append({
+        plugin = {
             "name": name,
             "url": url,
             "owner": owner,
@@ -255,11 +272,15 @@ def parse_plugins(readme_path: Path) -> list[dict]:
             "category": current_category,
             "platform": current_platform,
             "source": "awesome-ai-plugins",
-            "install_url": (
+        }
+        # DeepSeek Harness plugins are Cordis/npm modules and intentionally do
+        # not require a Codex-style .codex-plugin/plugin.json manifest.
+        if current_platform != DEEPSEEK_HARNESS_PLATFORM:
+            plugin["install_url"] = (
                 "https://raw.githubusercontent.com/"
                 f"{owner}/{repo}/HEAD/.codex-plugin/plugin.json"
-            ),
-        })
+            )
+        plugins.append(plugin)
 
     return sort_plugins(plugins)
 
@@ -283,6 +304,13 @@ def merge_readme_additions(
         if not key or key in seen:
             continue
         seen.add(key)
+
+        if plugin.get("platform") == DEEPSEEK_HARNESS_PLATFORM:
+            # DSH resolves package/git specs through `dsh plugin add`; a
+            # Codex manifest URL would be misleading and usually 404.
+            plugin.pop("install_url", None)
+            additions.append(normalize_plugin(plugin))
+            continue
 
         probed = probe_install_url(plugin["owner"], plugin["repo"])
         if probed:

--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -301,8 +301,26 @@ def merge_readme_additions(
     additions: list[dict] = []
     for plugin in parse_plugins(readme_path):
         key = normalize_repo_key(plugin)
-        if not key or key in seen:
+        if not key:
             continue
+
+        if key in seen:
+            # A repository can support multiple runtimes. Preserve a
+            # DeepSeek Harness contribution when the same repository already
+            # exists in an upstream Codex (or earlier README) catalog entry.
+            if plugin.get("platform") == DEEPSEEK_HARNESS_PLATFORM:
+                for existing in (*upstream, *additions):
+                    if normalize_repo_key(existing) != key:
+                        continue
+                    ecosystems = existing.get("ecosystems")
+                    if not isinstance(ecosystems, list) or not ecosystems:
+                        ecosystems = [existing.get("platform", "codex")]
+                        existing["ecosystems"] = ecosystems
+                    if DEEPSEEK_HARNESS_PLATFORM not in ecosystems:
+                        ecosystems.append(DEEPSEEK_HARNESS_PLATFORM)
+                    break
+            continue
+
         seen.add(key)
 
         if plugin.get("platform") == DEEPSEEK_HARNESS_PLATFORM:

--- a/tests/test-generate-plugins-json.py
+++ b/tests/test-generate-plugins-json.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import tempfile
 import unittest
+from datetime import date
 from pathlib import Path
 
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts/generate_plugins_json.py"
@@ -13,6 +14,11 @@ SPEC.loader.exec_module(MODULE)
 
 
 class GeneratePluginsJsonTests(unittest.TestCase):
+    def test_marketplace_timestamp_is_stable_for_the_day(self) -> None:
+        marketplace = MODULE.generate_marketplace_json([])
+
+        self.assertEqual(marketplace["last_updated"], date.today().isoformat())
+
     def test_merges_deepseek_ecosystem_into_existing_repository(self) -> None:
         upstream = [
             {

--- a/tests/test-generate-plugins-json.py
+++ b/tests/test-generate-plugins-json.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts/generate_plugins_json.py"
+SPEC = importlib.util.spec_from_file_location("generate_plugins_json", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class GeneratePluginsJsonTests(unittest.TestCase):
+    def test_merges_deepseek_ecosystem_into_existing_repository(self) -> None:
+        upstream = [
+            {
+                "name": "Shared Plugin",
+                "owner": "example",
+                "repo": "shared-plugin",
+                "platform": "codex",
+                "ecosystems": ["codex"],
+            }
+        ]
+
+        with tempfile.TemporaryDirectory() as directory:
+            readme = Path(directory) / "README.md"
+            readme.write_text(
+                "## Community Plugins\n\n"
+                "### DeepSeek Harness Plugins\n\n"
+                "- [Shared Plugin](https://github.com/example/shared-plugin) - A shared plugin.\n"
+            )
+
+            plugins, added = MODULE.merge_readme_additions(upstream, readme)
+
+        self.assertEqual(added, 0)
+        self.assertEqual(len(plugins), 1)
+        self.assertEqual(plugins[0]["ecosystems"], ["codex", "deepseek-harness"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a DeepSeek Harness plugin subsection with Cordis/npm packaging guidance.
- Generate ecosystem-aware metadata without assigning DSH entries a Codex manifest URL.
- Document the DeepSeek Harness contribution and scanner requirements.

## Testing
- `python3 -m py_compile scripts/generate_plugins_json.py scripts/validate-contribution.py scripts/check-alphabetical.py`
- `python3 scripts/check-alphabetical.py README.md`
- `python3 scripts/validate-contribution.py --base-ref origin/main`
