### PR TITLE
feat: add Grok and Kimi plugin support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,26 @@ Thank you for considering a contribution!
    ```
    - [Extension Name](https://github.com/owner/repo) - Description (max 1 sentence).
    ```
-4. **Add to appropriate section** - Codex plugins, Claude Code skills, Gemini extensions, DeepSeek Harness plugins, MCP servers, or Cross-AI tools
+4. **Add to appropriate section** - Codex plugins, Claude Code skills, Gemini extensions, Grok plugins, Kimi plugins, DeepSeek Harness plugins, MCP servers, or Cross-AI tools
+
+### Grok submissions
+
+Grok Build plugins can package skills, commands, agents, hooks, MCP servers, or
+LSP configuration. Include the repository's native `.grok-plugin/plugin.json`
+when the project uses one and document the tested
+`grok plugin install owner/repo --trust` flow. Review the [official xAI plugin
+marketplace](https://github.com/xai-org/plugin-marketplace) and [Grok plugin
+guide](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/09-plugins.md)
+before submitting.
+
+### Kimi submissions
+
+Kimi Code plugins can package skills, agents, and MCP servers. Current bundles
+use `kimi.plugin.json`; older bundles may use `.kimi-plugin/plugin.json` or
+`plugin.json`. Document a tested `/plugins install
+https://github.com/owner/repo` flow and follow the [official Kimi plugin
+documentation](https://github.com/MoonshotAI/kimi-code/blob/main/docs/en/customization/plugins.md)
+before submitting.
 
 ### DeepSeek Harness submissions
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 </p>
 
 <p align="center">
-  Discover extensions for Codex, ChatGPT, Claude Code, Gemini CLI, DeepSeek Harness, Cursor, OpenCode, and other compatible AI assistants from one community-maintained catalog.
+  Discover extensions for Codex, ChatGPT, Claude Code, Gemini CLI, Grok, Kimi, DeepSeek Harness, Cursor, OpenCode, and other compatible AI assistants from one community-maintained catalog.
 </p>
 
 <p align="center">
@@ -36,6 +36,8 @@
 - [Start Here](#start-here)
 - [Official Plugins](#official-plugins)
 - [Community Plugins](#community-plugins)
+  - [Grok Plugins](#grok-plugins)
+  - [Kimi Plugins](#kimi-plugins)
   - [DeepSeek Harness Plugins](#deepseek-harness-plugins)
 - [Formats & Development](#formats--development)
 - [Guides & Articles](#guides--articles)
@@ -331,6 +333,25 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Yandex Direct](https://github.com/nebelov/yandex-direct-for-all) - GitHub-ready Codex plugin bundle for Yandex Direct, Wordstat, Metrika, and Roistat.
 - [Zotero Research Tools](https://github.com/summer521521/Zotero_Research_plugin) - Connects Codex to Zotero Desktop for local-library search, citation export, collection and tag inspection, and research workflow support.
 
+### Grok Plugins
+
+xAI Grok Build plugins can bundle skills, commands, agents, hooks, MCP servers,
+and language-server configuration. A native plugin may include
+`.grok-plugin/plugin.json`; install a repository with `grok plugin install
+owner/repo --trust`. Add verified community plugins here in alphabetical order.
+See the [official xAI plugin marketplace](https://github.com/xai-org/plugin-marketplace)
+and [Grok plugin guide](https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/09-plugins.md)
+before submitting.
+
+### Kimi Plugins
+
+Kimi Code plugins package skills, agents, and MCP servers for the Kimi runtime.
+Depending on the plugin version, a repository can expose `kimi.plugin.json` or
+`.kimi-plugin/plugin.json`; install a GitHub repository with Kimi Code's
+`/plugins install https://github.com/owner/repo` command. Add verified community
+plugins here in alphabetical order. See the [official Kimi plugin documentation](https://github.com/MoonshotAI/kimi-code/blob/main/docs/en/customization/plugins.md)
+before submitting.
+
 ### DeepSeek Harness Plugins
 
 DeepSeek Harness (DSH) plugins are Cordis modules or npm packages that expose a
@@ -342,7 +363,7 @@ submitting a repository.
 
 ## Formats & Development
 
-AI extensions use several overlapping formats. Agent Skills provide reusable instructions, MCP servers expose tools and data, DeepSeek Harness loads Cordis modules/npm packages, and client-specific plugin manifests package those capabilities for installation. Prefer open formats where practical, then add client adapters for the assistants you support.
+AI extensions use several overlapping formats. Agent Skills provide reusable instructions, MCP servers expose tools and data, DeepSeek Harness loads Cordis modules/npm packages, and client-specific plugin manifests package those capabilities for installation. Grok Build and Kimi Code each have native plugin manifests and runtime installers. Prefer open formats where practical, then add client adapters for the assistants you support.
 
 ### Getting Started
 
@@ -385,6 +406,50 @@ Install a published package or GitHub package through the DSH profile manager:
 
 ```bash
 dsh plugin add <npm-package-or-github-spec>
+```
+
+### Grok Plugin Anatomy
+
+Grok Build plugins can group skills, commands, agents, hooks, MCP servers, and
+LSP configuration. A repository can describe the bundle with an optional
+`.grok-plugin/plugin.json` manifest and can publish it through a Grok
+marketplace catalog.
+
+```text
+my-plugin/
+├── .grok-plugin/
+│   └── plugin.json          # Optional native manifest
+├── skills/                  # Optional Agent Skills
+├── commands/                # Optional slash commands
+├── agents/                  # Optional subagents
+└── .mcp.json                # Optional MCP servers
+```
+
+Install a GitHub repository with:
+
+```bash
+grok plugin install owner/repo --trust
+```
+
+### Kimi Plugin Anatomy
+
+Kimi Code plugins can expose skills, agents, and MCP servers. Current Kimi Code
+plugins use `kimi.plugin.json`; earlier plugin bundles may use
+`.kimi-plugin/plugin.json` or `plugin.json`. Follow the repository's manifest
+and installation instructions.
+
+```text
+my-plugin/
+├── kimi.plugin.json         # Current Kimi Code manifest
+├── skills/                  # Optional skills
+├── agents/                  # Optional agents
+└── mcpServers/              # Optional MCP server definitions
+```
+
+Install a GitHub repository from Kimi Code with:
+
+```text
+/plugins install https://github.com/owner/repo
 ```
 
 ### Codex Plugin Creator
@@ -445,6 +510,8 @@ The score is best used as a quick trust signal and triage summary (not the only 
 - [Awesome DeepSeek Harness Plugins](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) - Community-maintained DSH plugin list and discovery reference.
 - [awesome-codex-plugins](https://github.com/hashgraph-online/awesome-codex-plugins) - Codex-focused catalog that inspired this cross-platform list.
 - [HOL Plugin Registry](https://hol.org/registry/plugins) - Browse plugins with scanner-backed security analysis and trust scores.
+- [Kimi Code](https://github.com/MoonshotAI/kimi-code) - Official Kimi Code runtime and plugin documentation.
+- [xAI Grok Plugin Marketplace](https://github.com/xai-org/plugin-marketplace) - Official Grok Build plugin marketplace and catalog format.
 
 ## Claim Your Plugin
 

--- a/SCANNER_GUIDE.md
+++ b/SCANNER_GUIDE.md
@@ -53,6 +53,22 @@ the runtime uses Cordis and `dsh.bundle` rather than a Codex manifest:
 
 **Passing criteria:** Score ≥ 80/142, with no critical or high severity findings.
 
+### Grok plugin checks
+
+Grok Build plugins should keep their native `.grok-plugin/plugin.json` manifest
+when the project uses one, document the tested `grok plugin install
+owner/repo --trust` flow, and keep the same scanner CI gate as every other
+ecosystem. The scanner result is a repository safety baseline; it does not
+replace Grok's runtime validation.
+
+### Kimi plugin checks
+
+Kimi Code plugins may use `kimi.plugin.json`, `.kimi-plugin/plugin.json`, or the
+older `plugin.json` manifest. Document the tested `/plugins install
+https://github.com/owner/repo` flow and keep the same scanner CI gate. The
+scanner result is a repository safety baseline; it does not replace Kimi's
+runtime validation.
+
 ### DeepSeek Harness package checks
 
 DeepSeek Harness plugins should keep the installable `dsh.bundle` declaration in

--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -34,19 +34,37 @@ INSTALL_PATH_CANDIDATES = (
     "plugins/{repo}/.codex-plugin/plugin.json",
     ".codex/plugin.json",
 )
+KIMI_MANIFEST_PATH_CANDIDATES = (
+    "kimi.plugin.json",
+    ".kimi-plugin/plugin.json",
+    "plugin.json",
+)
 INSTALL_URL_PROBE_TIMEOUT = 6.0
 DEEPSEEK_HARNESS_PLATFORM = "deepseek-harness"
+GROK_PLATFORM = "grok"
+KIMI_PLATFORM = "kimi"
+
+# Native runtime manifests should not inherit the Codex manifest fallback.
+PLATFORM_MANIFEST_PATHS = {
+    GROK_PLATFORM: ".grok-plugin/plugin.json",
+    KIMI_PLATFORM: "kimi.plugin.json",
+}
 
 # Community entries live under one README section. Keep the platform attached
-# to each subsection so a DeepSeek Harness entry is not misclassified as a
-# Codex plugin merely because both catalogs share the same human-readable
-# section.
+# to each subsection so native Grok, Kimi, and DeepSeek Harness entries are not
+# misclassified as Codex plugins merely because catalogs share one section.
 COMMUNITY_CATEGORY_PLATFORMS = {
+    "Grok Plugins": GROK_PLATFORM,
+    "Kimi Plugins": KIMI_PLATFORM,
     "DeepSeek Harness Plugins": DEEPSEEK_HARNESS_PLATFORM,
 }
 
 
-def probe_install_url(owner: str, repo: str) -> str | None:
+def probe_install_url(
+    owner: str,
+    repo: str,
+    candidates: tuple[str, ...] = INSTALL_PATH_CANDIDATES,
+) -> str | None:
     """Return the first GitHub raw URL that resolves for a plugin manifest.
 
     Used for README-only additions so non-root manifest layouts don't end up
@@ -54,7 +72,7 @@ def probe_install_url(owner: str, repo: str) -> str | None:
     on network errors or when no candidate exists; the caller decides whether
     to fall back to a default path or omit the field.
     """
-    for template in INSTALL_PATH_CANDIDATES:
+    for template in candidates:
         path = template.format(repo=repo)
         url = (
             f"https://raw.githubusercontent.com/{owner}/{repo}/HEAD/{path}"
@@ -108,7 +126,7 @@ def normalize_plugin(plugin: dict) -> dict:
     # Determine platform from upstream source field or fall back to codex
     upstream_source = str(plugin.get("source", "")).strip()
     if upstream_source == "awesome-grok-plugins":
-        entry.setdefault("platform", "grok")
+        entry.setdefault("platform", GROK_PLATFORM)
     else:
         entry.setdefault("platform", "codex")
 
@@ -201,6 +219,8 @@ PLATFORM_SECTIONS = {
     "OpenCode Plugins": "opencode",
     "Google Gemini CLI Plugins": "gemini-cli",
     "MCP Servers (Cross-Platform)": "mcp",
+    "Grok Plugins": GROK_PLATFORM,
+    "Kimi Plugins": KIMI_PLATFORM,
     "DeepSeek Harness Plugins": DEEPSEEK_HARNESS_PLATFORM,
     # Current README structure: a single `## Community Plugins` section with
     # `###` subcategories. Treat its entries as codex marketplace plugins.
@@ -273,9 +293,13 @@ def parse_plugins(readme_path: Path) -> list[dict]:
             "platform": current_platform,
             "source": "awesome-ai-plugins",
         }
-        # DeepSeek Harness plugins are Cordis/npm modules and intentionally do
-        # not require a Codex-style .codex-plugin/plugin.json manifest.
-        if current_platform != DEEPSEEK_HARNESS_PLATFORM:
+        manifest_path = PLATFORM_MANIFEST_PATHS.get(current_platform)
+        if manifest_path:
+            plugin["install_url"] = (
+                "https://raw.githubusercontent.com/"
+                f"{owner}/{repo}/HEAD/{manifest_path}"
+            )
+        elif current_platform != DEEPSEEK_HARNESS_PLATFORM:
             plugin["install_url"] = (
                 "https://raw.githubusercontent.com/"
                 f"{owner}/{repo}/HEAD/.codex-plugin/plugin.json"
@@ -305,10 +329,15 @@ def merge_readme_additions(
             continue
 
         if key in seen:
-            # A repository can support multiple runtimes. Preserve a
-            # DeepSeek Harness contribution when the same repository already
-            # exists in an upstream Codex (or earlier README) catalog entry.
-            if plugin.get("platform") == DEEPSEEK_HARNESS_PLATFORM:
+            # A repository can support multiple runtimes. Preserve a native
+            # runtime contribution when the same repository already exists in
+            # an upstream or earlier README catalog entry.
+            if plugin.get("platform") in {
+                DEEPSEEK_HARNESS_PLATFORM,
+                GROK_PLATFORM,
+                KIMI_PLATFORM,
+            }:
+                platform = plugin["platform"]
                 for existing in (*upstream, *additions):
                     if normalize_repo_key(existing) != key:
                         continue
@@ -316,17 +345,32 @@ def merge_readme_additions(
                     if not isinstance(ecosystems, list) or not ecosystems:
                         ecosystems = [existing.get("platform", "codex")]
                         existing["ecosystems"] = ecosystems
-                    if DEEPSEEK_HARNESS_PLATFORM not in ecosystems:
-                        ecosystems.append(DEEPSEEK_HARNESS_PLATFORM)
+                    if platform not in ecosystems:
+                        ecosystems.append(platform)
                     break
             continue
 
         seen.add(key)
 
         if plugin.get("platform") == DEEPSEEK_HARNESS_PLATFORM:
-            # DSH resolves package/git specs through `dsh plugin add`; a
-            # Codex manifest URL would be misleading and usually 404.
+            # Native runtimes resolve repository sources through their own
+            # installers/manifests; never probe or substitute a Codex path.
             plugin.pop("install_url", None)
+            additions.append(normalize_plugin(plugin))
+            continue
+
+        if plugin.get("platform") == KIMI_PLATFORM:
+            probed = probe_install_url(
+                plugin["owner"],
+                plugin["repo"],
+                KIMI_MANIFEST_PATH_CANDIDATES,
+            )
+            if probed:
+                plugin["install_url"] = probed
+            additions.append(normalize_plugin(plugin))
+            continue
+
+        if plugin.get("platform") == GROK_PLATFORM:
             additions.append(normalize_plugin(plugin))
             continue
 
@@ -403,8 +447,8 @@ def main():
                 for existing in plugins:
                     if normalize_repo_key(existing) == key:
                         ecos = existing.get("ecosystems", [])
-                        if "grok" not in ecos:
-                            ecos.append("grok")
+                        if GROK_PLATFORM not in ecos:
+                            ecos.append(GROK_PLATFORM)
                             existing["ecosystems"] = ecos
                         break
             else:

--- a/scripts/generate_plugins_json.py
+++ b/scripts/generate_plugins_json.py
@@ -39,6 +39,7 @@ KIMI_MANIFEST_PATH_CANDIDATES = (
     ".kimi-plugin/plugin.json",
     "plugin.json",
 )
+GROK_MANIFEST_PATH_CANDIDATES = (".grok-plugin/plugin.json",)
 INSTALL_URL_PROBE_TIMEOUT = 6.0
 DEEPSEEK_HARNESS_PLATFORM = "deepseek-harness"
 GROK_PLATFORM = "grok"
@@ -371,6 +372,15 @@ def merge_readme_additions(
             continue
 
         if plugin.get("platform") == GROK_PLATFORM:
+            probed = probe_install_url(
+                plugin["owner"],
+                plugin["repo"],
+                GROK_MANIFEST_PATH_CANDIDATES,
+            )
+            if probed:
+                plugin["install_url"] = probed
+            else:
+                plugin.pop("install_url", None)
             additions.append(normalize_plugin(plugin))
             continue
 

--- a/tests/test-generate-plugins-json.py
+++ b/tests/test-generate-plugins-json.py
@@ -44,6 +44,56 @@ class GeneratePluginsJsonTests(unittest.TestCase):
         self.assertEqual(len(plugins), 1)
         self.assertEqual(plugins[0]["ecosystems"], ["codex", "deepseek-harness"])
 
+    def test_parses_native_grok_and_kimi_sections(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            readme = Path(directory) / "README.md"
+            readme.write_text(
+                "## Community Plugins\n\n"
+                "### Grok Plugins\n\n"
+                "- [Grok Demo](https://github.com/example/grok-demo) - Grok plugin.\n\n"
+                "### Kimi Plugins\n\n"
+                "- [Kimi Demo](https://github.com/example/kimi-demo) - Kimi plugin.\n"
+            )
+
+            plugins = MODULE.parse_plugins(readme)
+
+        self.assertEqual(
+            [(plugin["name"], plugin["platform"]) for plugin in plugins],
+            [("Grok Demo", "grok"), ("Kimi Demo", "kimi")],
+        )
+        self.assertEqual(
+            plugins[0]["install_url"],
+            "https://raw.githubusercontent.com/example/grok-demo/HEAD/.grok-plugin/plugin.json",
+        )
+        self.assertEqual(
+            plugins[1]["install_url"],
+            "https://raw.githubusercontent.com/example/kimi-demo/HEAD/kimi.plugin.json",
+        )
+
+    def test_merges_kimi_ecosystem_into_existing_repository(self) -> None:
+        upstream = [
+            {
+                "name": "Shared Plugin",
+                "owner": "example",
+                "repo": "shared-plugin",
+                "platform": "codex",
+                "ecosystems": ["codex"],
+            }
+        ]
+
+        with tempfile.TemporaryDirectory() as directory:
+            readme = Path(directory) / "README.md"
+            readme.write_text(
+                "## Community Plugins\n\n"
+                "### Kimi Plugins\n\n"
+                "- [Shared Plugin](https://github.com/example/shared-plugin) - A shared plugin.\n"
+            )
+
+            plugins, added = MODULE.merge_readme_additions(upstream, readme)
+
+        self.assertEqual(added, 0)
+        self.assertEqual(plugins[0]["ecosystems"], ["codex", "kimi"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test-generate-plugins-json.py
+++ b/tests/test-generate-plugins-json.py
@@ -5,6 +5,7 @@ import tempfile
 import unittest
 from datetime import date
 from pathlib import Path
+from unittest.mock import patch
 
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts/generate_plugins_json.py"
 SPEC = importlib.util.spec_from_file_location("generate_plugins_json", SCRIPT_PATH)
@@ -93,6 +94,21 @@ class GeneratePluginsJsonTests(unittest.TestCase):
 
         self.assertEqual(added, 0)
         self.assertEqual(plugins[0]["ecosystems"], ["codex", "kimi"])
+
+    def test_omits_optional_grok_manifest_when_probe_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            readme = Path(directory) / "README.md"
+            readme.write_text(
+                "## Community Plugins\n\n"
+                "### Grok Plugins\n\n"
+                "- [Grok Demo](https://github.com/example/grok-demo) - Grok plugin.\n"
+            )
+
+            with patch.object(MODULE, "probe_install_url", return_value=None):
+                plugins, added = MODULE.merge_readme_additions([], readme)
+
+        self.assertEqual(added, 1)
+        self.assertNotIn("install_url", plugins[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- document Grok Build and Kimi Code plugin contribution formats and scanner expectations
- teach the catalog generator to classify native Grok/Kimi entries and resolve their manifests
- add parser regression coverage for native ecosystems and multi-runtime repositories

## Validation

- `python3 -m py_compile scripts/generate_plugins_json.py`
- `python3 tests/test-generate-plugins-json.py`
- `python3 tests/test-sync-scanner-action.py`
- `python3 scripts/check-alphabetical.py README.md`
