### PR TITLE
Add GoodMemory to Kimi Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,8 @@ Depending on the plugin version, a repository can expose `kimi.plugin.json` or
 plugins here in alphabetical order. See the [official Kimi plugin documentation](https://github.com/MoonshotAI/kimi-code/blob/main/docs/en/customization/plugins.md)
 before submitting.
 
+- [GoodMemory](https://github.com/hjqcan/GoodMemory) - Local-first, auditable cross-session project memory for Kimi Code with scoped recall, traceable provenance, and approval-gated writes.
+
 ### DeepSeek Harness Plugins
 
 DeepSeek Harness (DSH) plugins are Cordis modules or npm packages that expose a


### PR DESCRIPTION
## Summary

Add [GoodMemory](https://github.com/hjqcan/GoodMemory) to the native Kimi Code plugins section. GoodMemory provides local-first cross-session project memory, scoped recall, recall tracing, and approval-gated writes through its MCP integration.

## Installation

```text
/plugins install https://github.com/hjqcan/GoodMemory
```

Native manifest: [`kimi.plugin.json`](https://github.com/hjqcan/GoodMemory/blob/v0.7.5/kimi.plugin.json)
Setup guide: [GoodMemory Kimi Code Setup Guide](https://github.com/hjqcan/GoodMemory/blob/v0.7.5/docs/GoodMemory-Kimi-Code-Setup-Guide.md)
Current stable release: [`v0.7.5`](https://github.com/hjqcan/GoodMemory/releases/tag/v0.7.5)

The manifest contract matches the current official Kimi Code plugin specification:
https://github.com/MoonshotAI/kimi-code/blob/main/docs/en/customization/plugins.md#plugin-manifest

## Validation

- `python3 scripts/check-alphabetical.py README.md`
- `python3 tests/test-generate-plugins-json.py`
- `git diff --check`
- [GoodMemory native Kimi scanner run](https://github.com/hjqcan/GoodMemory/actions/runs/32461584433/job/96709422365): 93/A, 0 critical, 0 high

The scanner result verifies the source bundle against the catalog gate. It is not evidence of independent adoption. GoodMemory's setup guide records v0.7.2 as the last clean Kimi acceptance boundary until a fresh v0.7.5 end-to-end run is recorded.
