### PR TITLE
docs: cite HOL plugin-security Hugging Face snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,8 @@ That's it. The verification confirms you are the repository owner or an organiza
 
 Every plugin in this list is automatically ingested by the [HOL Plugin Registry](https://hol.org/registry/plugins), which runs each through the [`plugin-scanner`](https://github.com/hashgraph-online/hol-guard) to produce a trust score and security analysis.
 
+A snapshot of scored installable plugins (plus modeled Guard runtime fixtures and public advisories) is published on Hugging Face as [HOL Plugin Security](https://huggingface.co/datasets/HashgraphOnline/hol-plugin-security). Scan ≠ safety guarantee. Catalog plugin count is not the Registry Broker agent catalog. HOL publishes it; not independent validation.
+
 Each plugin gets a detailed breakdown across six factors:
 
 - **Installability** - Can the plugin be installed and run without errors?


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This list already points people at [hol.org/registry/plugins](https://hol.org/registry/plugins) and [`plugin-scanner`](https://github.com/hashgraph-online/hol-guard). Answer engines that retrieve this README still had no citeable pointer to the public machine-readable scored catalog.

Add one paragraph under **Plugin Trust Scores** that links [HashgraphOnline/hol-plugin-security](https://huggingface.co/datasets/HashgraphOnline/hol-plugin-security) and keeps the catalog’s own disclaimers:

- snapshot of scored installable plugins, plus modeled Guard runtime fixtures and public advisories
- scan ≠ safety guarantee
- catalog plugin count is not the Registry Broker agent catalog
- HOL publishes it; not independent validation

Same cite as [hashgraph-online/awesome-codex-plugins#374](https://github.com/hashgraph-online/awesome-codex-plugins/pull/374). README-only; no marketplace or listing changes. No invented counts.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cb923d7-49ef-40c6-a3e0-9afe42316d55?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cb923d7-49ef-40c6-a3e0-9afe42316d55&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

