### PR TITLE
Add Coordinate Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Commit Narrator](./plugins/mturac/commit-narrator) - Generate semantic commit message from staged diff, including the _why_.
 - [coffee-paladin](https://github.com/pawelkwaczynski/coffee-paladin) - Thermal guard for Apple Silicon: pauses hot jobs before the Mac throttles and gates Claude Code, Codex and Gemini CLI before heavy commands.
 - [Context Guard](https://github.com/GreenLv/codex-context-guard) - Preserves authoritative requirements and verification evidence across long-running Codex tasks and context compaction.
+- [Coordinate Agents](https://github.com/hogancv/coordinate-agents) - Plugin-first multi-agent coordination tool with a local-first, recoverable Agent Bus and human-gated planning, implementation, review, and release workflows.
 - [Cover My Repo](https://github.com/sjh9714/cover-my-repo) - Designs three checked GitHub social preview cards with Codex or Cursor, then renders them locally with Chrome.
 - [debt-ops](https://github.com/bcanfield/agentic-tech-debt) - Catches AI-introduced tech debt at write-time: hooks log every deferral to a registry in your repo and a review skill ranks paydown by file churn.
 - [Deps Doctor](./plugins/mturac/deps-doctor) - Multi-ecosystem dependency audit (npm, pip, cargo, go) in one report.


### PR DESCRIPTION
## Summary

Adds [Coordinate Agents](https://github.com/hogancv/coordinate-agents) to the Community Plugins section. It is a plugin-first multi-agent coordination tool built around a local-first, recoverable Agent Bus.

## Verification

- listing format and alphabetical order validated
- required scanner CI is present and passes with no critical or high findings