### PR TITLE
Add taskflow to Grok Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [tailtest](https://github.com/avansaber/tailtest-codex) - Hook-powered test generation -- detects files changed during an agent turn and instructs Codex to write and run tests automatically. Zero config, 8 languages.
 - [Tandem Workflow Architect](https://github.com/frumu-ai/tandem-codex-plugin) - Plan Tandem workflows in Codex, then validate, preview, and run them through the governed Tandem engine.
 - [Tartiner Labs](https://github.com/tartinerlabs/skills) - Agent skills for git workflows, GitHub automation, security audits, code refactoring, and project tooling.
+- [taskflow](https://github.com/heggria/taskflow) - Declarative, verifiable DAG orchestration for Grok Build subagents — fan-out, gates, loops, tournaments, approvals, and resumable runs via MCP tools, with intermediate transcripts kept out of context.
 - [Team Skills Platform](https://github.com/Colin4k1024/tsp) - Role-based team delivery framework — Tech Lead-orchestrated 8-role system with 195+ skills, 27 specialist agents, 80+ commands, hooks, and ECC harness for Claude Code, Codex, and OpenCode.
 - [Test Gap](./plugins/mturac/test-gap) - Find lines in your diff lacking test coverage (Cobertura, lcov, coverage.json).
 - [TODO Harvest](./plugins/mturac/todo-harvest) - TODO/FIXME/HACK scan with `git blame` author + age.


### PR DESCRIPTION
## Summary

Add [taskflow](https://github.com/heggria/taskflow) under **Grok Plugins** (first community entry; alphabetical).

taskflow is a declarative, verifiable DAG runtime for coding-agent workflows. The Grok Build delivery is `grok-taskflow`: native `.grok-plugin/plugin.json`, a routing skill, and `taskflow_*` MCP tools (run / verify / compile / resume / save / search, …).

## Install (verified from the project's docs, not an imagined marketplace source)

A public Grok plugin marketplace string is **not** published yet. From a checkout:

```sh
grok plugin install ./packages/grok-taskflow/plugin --trust
```

Published MCP (npm `beta`):

```sh
grok mcp add taskflow -- npx -y -p grok-taskflow@beta grok-taskflow-mcp
```

## Scanner

HOL `plugin-scanner` GitHub Action is on `heggria/taskflow` (`hashgraph-online/ai-plugin-scanner-action@55616c96`, tag v1.2.515).

Local `plugin-scanner scan .` on current main: **74/100**, 0 critical, 12 high — almost all test-fixture secret/eval hits, plus two shell-interpolation findings. Not claiming a pass. Action is `continue-on-error` until those are triaged.

## Honesty

Not GA. npm current line is `0.3.0-beta.1.2`. Does not implement `/tf web` or adaptive-authority isolation.

Invited by hashgraph-online/awesome-ai-plugins via heggria/taskflow#144.