### PR TITLE
Add site-risk-check (Claude Code / Codex / Gemini skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Secret Guard](./plugins/mturac/secret-guard) - Pre-commit secret scanner using pattern and entropy detection.
 - [Session Orchestrator](https://github.com/Kanevry/session-orchestrator) - Session orchestration for Claude Code, Codex, and Cursor IDE — structured planning, wave-based execution, VCS integration (GitLab + GitHub), quality gates, and clean session close-out with issue tracking.
 - [Simple Man](https://github.com/Maksim-Burtsev/simple-man) - High-compression communication mode for Codex agents that removes filler while preserving search, validation, and implementation effort.
+- [site-risk-check](https://github.com/kobimantzur/agent-skills) - Zero-dependency skill that scans a live URL for the conditions behind accessibility and privacy demand letters — trackers firing before consent, missing policies, and machine-checkable WCAG gaps — mapped to the jurisdictions the site actually sells to.
 - [skill-sync-publisher](https://github.com/liuyewang/skill-sync-publisher) - Safely synchronize this Codex skill across public agent-skill registries.
 - [skillsaw](https://github.com/stbenjam/skillsaw) - A configurable linter for agent skills, plugins, and AI coding assistant context.
 - [SOTA Engineering Skills](https://github.com/martinholovsky/SOTA-skills) - Router-mapped library of 40 domain and language skills with BUILD and AUDIT modes, loading only the rules a task needs and ending every rules file in an audit checklist.


### PR DESCRIPTION
Adds **site-risk-check** to Community Plugins → Development & Workflow (alphabetical, after "Simple Man").

**What it is:** a zero-dependency skill that scans a live URL for the conditions behind accessibility and privacy demand letters — trackers/session-recording firing before consent, missing privacy/cookie policies, and machine-checkable WCAG gaps — then maps each finding to the jurisdictions the storefront actually ships to (GDPR, CCPA, ADA, IS 5568). Plain-English output; never claims "compliant" and always reports what it could not check.

- Repo: https://github.com/kobimantzur/agent-skills
- License: MIT
- Works in Claude Code, Codex, Gemini CLI (reads the SKILL.md standard)
- Pure Python stdlib — no pip install, no API keys, no paid services
- Treats the scanned page as untrusted input: rule/jurisdiction selection comes only from structured detection, never page prose

**Scanner:** HOL AI Plugin Scanner runs in CI and passes — score 89/100, 0 critical / 0 high findings.