### PR TITLE
chore: sync scanner action to v1.2.531

### DIFF
--- a/.github/workflows/sweep-open-prs.yml
+++ b/.github/workflows/sweep-open-prs.yml
@@ -84,7 +84,7 @@ jobs:
           CONTRIBUTION_URL: https://github.com/${{ matrix.contribution.owner }}/${{ matrix.contribution.repo }}.git
         run: git clone --depth 1 "$CONTRIBUTION_URL" "$RUNNER_TEMP/contributed"
       - name: Run HOL AI Plugin Scanner
-        uses: hashgraph-online/ai-plugin-scanner-action@55616c962cf86368423f7673b2ecdfdbe613d1af # v1.2.515
+        uses: hashgraph-online/ai-plugin-scanner-action@432eebe0fb9212be97c8d15cb1da9668a91e7914 # v1.2.531
         with:
           plugin_dir: ${{ runner.temp }}/contributed
           mode: scan

--- a/.github/workflows/validate-contribution.yml
+++ b/.github/workflows/validate-contribution.yml
@@ -60,7 +60,7 @@ jobs:
           CONTRIBUTION_URL: https://github.com/${{ matrix.contribution.owner }}/${{ matrix.contribution.repo }}.git
         run: git clone --depth 1 "$CONTRIBUTION_URL" "$RUNNER_TEMP/contributed"
       - name: Run HOL AI Plugin Scanner
-        uses: hashgraph-online/ai-plugin-scanner-action@55616c962cf86368423f7673b2ecdfdbe613d1af # v1.2.515
+        uses: hashgraph-online/ai-plugin-scanner-action@432eebe0fb9212be97c8d15cb1da9668a91e7914 # v1.2.531
         with:
           plugin_dir: ${{ runner.temp }}/contributed
           mode: scan

--- a/SCANNER_GUIDE.md
+++ b/SCANNER_GUIDE.md
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: hashgraph-online/ai-plugin-scanner-action@55616c962cf86368423f7673b2ecdfdbe613d1af # v1.2.515
+      - uses: hashgraph-online/ai-plugin-scanner-action@432eebe0fb9212be97c8d15cb1da9668a91e7914 # v1.2.531
         with:
           plugin_dir: "."
           min_score: 80


### PR DESCRIPTION
## Summary

- update the documented scanner Action pin to the current immutable v1.2.531 commit
- update both catalog validation workflows to the same pin
- preserve the existing scan mode, score threshold, and severity gate

The repository sync script generates this exact three-file diff. Its scheduled run already resolved v1.2.531 correctly, but the final push is rejected because the workflow GitHub App token cannot update workflow files without `workflows` permission: https://github.com/hashgraph-online/awesome-ai-plugins/actions/runs/32453402811

This scanner release contains support for the native `kimi.plugin.json` manifest documented by the current [MoonshotAI/kimi-code plugin specification](https://github.com/MoonshotAI/kimi-code/blob/main/docs/en/customization/plugins.md#plugin-manifest). That support is used by the reopened GoodMemory listing #95 while keeping every contribution on the same immutable scanner baseline.

## Verification

- `python3 -m unittest tests/test-sync-scanner-action.py`
- `python3 scripts/sync-scanner-action.py --check`
- `git diff --check`
