### PR TITLE
Add Agentic Ship to Development & Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Agent Guard](https://github.com/JeongJaeSoon/agent-guard) - Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI.
 - [Agent Harness Skills](https://github.com/yfge/agent-harness-skills) - Designs agent-ready repository harnesses with entrypoints, validation surfaces, runtime evidence, delivery records, and atomic commit guidance.
 - [Agent Workflow System](https://github.com/1139030773-cmd/agent-workflow-system) - 一套中文AI工作流系统：7个协作技能 + 行为规范宪法 + 会话恢复机制，模糊目标→可执行任务，全生命周期引导。Codex & Claude Code 双平台，新手友好。
+- [Agentic Ship](https://github.com/moasq/agentic-ship) - Cross-host product-development toolkit for Claude Code, Codex, Cursor, Hermes, and OpenClaw with shared rules, specialist roles, service connections, and machine-checked UI, backend, security, and launch gates.
 - [Agentizer](https://github.com/Humiris/wwa-transform) - Turn any website into an AI-powered agentfront with split-pane
 - [AgentOps](https://github.com/boshu2/agentops) - DevOps layer for coding agents with flow, feedback, and memory that compounds between sessions.
 - [AgentPack](https://github.com/vishal2612200/agentpack) - Ranks repo context for Codex with likely files, skill recommendations, agent rules, commands, warnings, and compact task-focused packs before editing.


### PR DESCRIPTION
## Summary

Add Agentic Ship to the Development & Workflow section. It is a tool-only product-development system with shared rules, specialist roles, service-connection handoffs, and deterministic delivery gates across Claude Code, Codex, Cursor, Hermes, and OpenClaw.

## Verification

- Source scanner workflow is live on `main` and pinned to `hashgraph-online/ai-plugin-scanner-action@55616c962cf86368423f7673b2ecdfdbe613d1af`.
- HOL Plugin Scanner 2.0.1116: 99/100 with zero critical or high findings.
- `scripts/check-alphabetical.py README.md`
- `scripts/validate-contribution.py --base-ref upstream/main`
- Catalog unit tests: 9 passed

Source prerequisite: [moasq/agentic-ship#44](https://github.com/moasq/agentic-ship/pull/44)