### PR TITLE
Add Cover My Repo to Development & Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex Usage and Resets](https://github.com/joelfarthing/codex-usage-and-resets) - Turns Codex usage into planning facts with linear pace, projected exhaustion, banked-reset expirations, and conservative unexpected-reset detection.
 - [Commit Narrator](./plugins/mturac/commit-narrator) - Generate semantic commit message from staged diff, including the _why_.
 - [Context Guard](https://github.com/GreenLv/codex-context-guard) - Preserves authoritative requirements and verification evidence across long-running Codex tasks and context compaction.
+- [Cover My Repo](https://github.com/sjh9714/cover-my-repo) - Designs three checked GitHub social preview cards with Codex or Cursor, then renders them locally with Chrome.
 - [debt-ops](https://github.com/bcanfield/agentic-tech-debt) - Catches AI-introduced tech debt at write-time: hooks log every deferral to a registry in your repo and a review skill ranks paydown by file churn.
 - [Deps Doctor](./plugins/mturac/deps-doctor) - Multi-ecosystem dependency audit (npm, pip, cargo, go) in one report.
 - [Designer Skill](https://github.com/Pythoughts-labs/designer-skill) - Plug-and-play MCP that gives your agent UI superpowers. One install: design skill + MCP server, zero config.


### PR DESCRIPTION
Adds Cover My Repo, a Codex and Cursor skill plus npm CLI that designs three GitHub social preview cards and renders them locally with Chrome.

I tested the npm CLI with Codex and Chrome. The source repository runs the pinned HOL scanner action on pushes and pull requests. The current scanner result is 85 with no high or critical findings.