### PR TITLE
feat(ci): make maintainer scanner CI optional for listings

### DIFF
--- a/.github/workflows/sweep-open-prs.yml
+++ b/.github/workflows/sweep-open-prs.yml
@@ -74,6 +74,7 @@ jobs:
     needs: discover
     if: needs.discover.outputs.matrix != '[]'
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -111,14 +112,14 @@ jobs:
             exit 1
           fi
           if [[ "$HAS_VALIDATION_FAILURES" == "true" ]]; then
-            echo "One or more open contributions are missing required scanner CI."
+            echo "One or more open contributions failed catalog validation."
             exit 1
           fi
           if [[ "$SCAN_RESULT" != "success" && "$SCAN_RESULT" != "skipped" ]]; then
-            echo "One or more source-repository scanner jobs failed."
-            exit 1
+            echo "scan findings: one or more advisory source-repository scanner jobs did not pass."
+            exit 0
           fi
-          echo "All checked open contributions satisfy the scanner gate."
+          echo "Catalog validation passed. Centralized scanner results are advisory."
 
   publish:
     name: Publish per-PR contribution checks

--- a/.github/workflows/validate-contribution.yml
+++ b/.github/workflows/validate-contribution.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: "3.12"
       - name: Install validator dependencies
         run: python3 -m pip install --disable-pip-version-check --no-input "PyYAML==6.0.2"
-      - name: Validate changed entries and source scanner CI
+      - name: Validate changed catalog entries
         env:
           BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || 'origin/main' }}
           GITHUB_TOKEN: ${{ github.token }}
@@ -50,6 +50,7 @@ jobs:
     needs: validate
     if: needs.validate.outputs.matrix != '[]'
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,24 +50,16 @@ The registry profile includes a standard **dofollow backlink** to the extension'
 Before submitting:
 
 ```bash
-# Run the HOL Plugin Scanner (required for all submissions)
+# Optional local preflight
 pipx run plugin-scanner lint .
 pipx run plugin-scanner verify .
 ```
 
-**Scanner Requirements (Mandatory for This List):**
-
-All plugins submitted to **Awesome AI Plugins** must pass the HOL AI Plugin Scanner:
-
-| Requirement | Threshold |
-|-------------|-----------|
-| **Score** | ≥ 80 / 142 |
-| **Severity** | No critical or high findings |
-| **CI** | Scanner must run in your repo's GitHub Actions |
+Scanner CI is optional. HOL scans listed projects independently. Projects that maintain the scanner in their own CI receive the full trust score; projects without it remain eligible and receive a 10% trust-score reduction for missing continuous security verification.
 
 See the full guide: [`SCANNER_GUIDE.md`](./SCANNER_GUIDE.md)
 
-### Why scanner CI is required
+### Why scanner CI is still useful
 
 AI extensions can register hooks, execute commands, read environment variables, and influence an agent's behavior. A compromised extension can therefore affect users outside the original repository. Scanner CI gives every community listing the same reproducible baseline for identifying:
 
@@ -77,7 +69,7 @@ AI extensions can register hooks, execute commands, read environment variables, 
 - unpinned third-party actions and dependencies;
 - malformed or misleading extension metadata.
 
-A passing scan is not a guarantee that an extension is harmless. It is reviewable evidence that every listed project cleared the same minimum checks, which helps maintainers catch common supply-chain risks before users install the extension.
+A passing scan is not a guarantee that an extension is harmless. It is reviewable evidence that helps maintainers catch common supply-chain risks. HOL still scans listed projects independently.
 
 ### What the scanner workflow can access
 
@@ -94,17 +86,16 @@ The example in [`SCANNER_GUIDE.md`](./SCANNER_GUIDE.md) pins GitHub Actions to i
 
 Pull requests that add a Community Plugin entry, including the DeepSeek Harness
 Plugins subsection, are checked automatically by
-`.github/workflows/validate-contribution.yml`. The check confirms that the
-linked public repository runs `hashgraph-online/ai-plugin-scanner-action` from
-GitHub Actions, then scans the contributed repository with the same score and
-severity thresholds above.
+`.github/workflows/validate-contribution.yml`. Catalog format, section, and
+discovery checks are required. Scanner CI in the source repository is optional.
+HOL clones and scans each valid new source repository; those scan results are
+advisory and do not block a valid listing.
 
 Existing open pull requests are covered by the scheduled and manually
 dispatchable `.github/workflows/sweep-open-prs.yml` workflow. It reviews each
-PR's exact README base/head revisions without executing fork code, reports
-missing scanner CI, runs the scanner for entries that pass the CI check, and
-publishes the result on each PR head. Failed checks update one remediation
-comment on the PR, tag the contributor, and link the scanner setup guidance.
+PR's exact README base/head revisions without executing fork code, queues an
+advisory scan, and publishes the result on each PR head. Reruns update the
+existing bot comment and check in place.
 
 Use scanner outputs as evidence for maintainers/reviewers:
 - Structural lint results

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ New extension workflow:
 
 1. Choose the clients and open formats you support
 2. Build the plugin, skill, MCP server, app, or agent tool
-3. **Validate with [`plugin-scanner`](https://github.com/hashgraph-online/hol-guard)** — **Required: score ≥ 80, no high/critical findings**
-4. **Gate PRs with the [HOL scanner GitHub Action](https://github.com/hashgraph-online/ai-plugin-scanner-action)** — **Required for listing**
+3. **Validate with [`plugin-scanner`](https://github.com/hashgraph-online/hol-guard)** — recommended local preflight
+4. **Optionally add the [HOL scanner GitHub Action](https://github.com/hashgraph-online/ai-plugin-scanner-action)** — optional continuous scanning
 5. Ship or submit with confidence
 
 ### Quick preflight
@@ -65,15 +65,9 @@ pipx run plugin-scanner lint .
 pipx run plugin-scanner verify .
 ```
 
-### Scanner Requirements (Mandatory for This List)
+### Scanner CI (Optional)
 
-All plugins submitted to **Awesome AI Plugins** must pass the HOL AI Plugin Scanner:
-
-| Requirement  | Threshold                                      |
-| ------------ | ---------------------------------------------- |
-| **Score**    | ≥ 80 / 130                                     |
-| **Severity** | No critical or high findings                   |
-| **CI**       | Scanner must run in your repo's GitHub Actions |
+Scanner CI is optional. HOL scans listed projects independently. Projects that maintain the scanner in their own CI receive the full trust score; projects without it remain eligible and receive a 10% trust-score reduction for missing continuous security verification.
 
 See the full guide: [`SCANNER_GUIDE.md`](./SCANNER_GUIDE.md)  
 See contributing requirements: [`CONTRIBUTING.md`](./CONTRIBUTING.md)
@@ -576,8 +570,7 @@ Contributions welcome! Please read the [contribution guidelines](CONTRIBUTING.md
 
 To add a plugin:
 
-1. Set up the HOL Plugin Scanner in your plugin repo (see [CONTRIBUTING.md](CONTRIBUTING.md))
-2. Fork this repo and add a single line to the appropriate section in `README.md` (alphabetical order)
-3. Submit a PR with your scanner score and plugin repo URL
+1. Fork this repo and add a single line to the appropriate section in `README.md` (alphabetical order)
+2. Submit a PR with the plugin repo URL. Scanner CI in the source repository is optional.
 
 **You do not need to copy plugin files into this repo.** A generator fetches your bundle from your source repo and regenerates catalog files automatically.

--- a/SCANNER_GUIDE.md
+++ b/SCANNER_GUIDE.md
@@ -73,9 +73,8 @@ runtime validation.
 
 DeepSeek Harness plugins should keep the installable `dsh.bundle` declaration in
 `package.json`, export a Cordis `apply(ctx)` entry point, and document a tested
-`dsh plugin add <package-or-github-spec>` flow. The scanner CI gate remains the
-same for every ecosystem: score at least 80 and fail on high or critical
-findings.
+`dsh plugin add <package-or-github-spec>` flow. Scanner CI is optional for
+every ecosystem. HOL still scans listed projects independently.
 
 ## CI/CD Integration
 
@@ -113,13 +112,9 @@ The recommended workflow is intentionally constrained:
 
 Review the [action source](https://github.com/hashgraph-online/ai-plugin-scanner-action) and pinned commit before enabling it. A passing result is a consistent baseline for community review, not a claim that software is risk-free.
 
-### Required for Awesome AI Plugins listing
+### Optional for Awesome AI Plugins listing
 
-All plugins submitted to this list must:
-
-1. **Score ≥ 80/142** in the scanner
-2. **Have zero critical or high findings**
-3. **Run the scanner in CI/CD** (GitHub Actions preferred)
+Scanner CI is optional. HOL scans listed projects independently. Projects that maintain the scanner in their own CI receive the full trust score; projects without it remain eligible and receive a 10% trust-score reduction for missing continuous security verification.
 
 Add the scanner badge to your README:
 

--- a/scripts/publish-open-pr-checks.py
+++ b/scripts/publish-open-pr-checks.py
@@ -100,22 +100,29 @@ def check_summary(result: dict[str, object], scanner_jobs: dict[int, list[str]])
         return (
             "failure",
             "Contribution requirements failed",
-            "Required scanner CI is missing or could not be validated.\n\n" + details,
+            "Catalog validation failed.\n\n" + details,
         )
 
     if state == "scan":
         jobs = scanner_jobs.get(number, [])
-        if jobs and all(conclusion == "success" for conclusion in jobs):
+        if not jobs:
             return (
                 "success",
-                "Contribution scan passed",
-                f"All {len(jobs)} source-repository scanner job(s) passed the contribution gate.",
+                "scan unavailable",
+                "HOL centralized scan could not run. Catalog validation passed; scanner results are advisory.",
             )
-        job_details = ", ".join(jobs) if jobs else "no scanner job was recorded"
+        if all(conclusion == "success" for conclusion in jobs):
+            return (
+                "success",
+                "scan passed",
+                f"All {len(jobs)} source-repository scanner job(s) passed. Catalog validation passed.",
+            )
+        job_details = ", ".join(jobs)
         return (
-            "failure",
-            "Contribution scan failed",
-            f"One or more source-repository scanner jobs did not pass: {job_details}.",
+            "success",
+            "scan findings",
+            "HOL centralized scan reported findings or did not pass: "
+            f"{job_details}. This is advisory and does not block listing.",
         )
 
     raise RuntimeError(f"unknown validator result state: {state}")
@@ -153,28 +160,29 @@ def remediation_comment(
     author_login = result.get("author_login")
     mention = f"@{author_login}" if isinstance(author_login, str) and GITHUB_LOGIN_RE.fullmatch(author_login) else "the contributor"
     if conclusion == "success":
+        optional_guidance = ""
+        if "scan findings" in check_title:
+            optional_guidance = (
+                "\n\nHOL's centralized scan reported findings. This does not block listing. "
+                "Optional scanner CI in the source repository receives the full trust score; "
+                "projects without it remain eligible with a 10% trust-score reduction.\n"
+            )
+        elif "scan unavailable" in check_title:
+            optional_guidance = (
+                "\n\nHOL's centralized scan could not run. This does not block listing.\n"
+            )
         return (
             f"{COMMENT_MARKER}\n\n"
-            f"✅ **Contribution gate passed.** {mention}, no action is required.\n\n"
-            f"The previous contribution-gate failure is resolved. "
+            f"✅ **Contribution check passed.** {mention}, catalog validation succeeded.\n\n"
+            f"### {check_title}\n{summary}{optional_guidance}\n"
             f"[View the latest sweep]({run_url})."
         )
 
-    if result.get("state") == "failure":
-        guidance = (
-            "1. Add a workflow under `.github/workflows/` in the linked source repository.\n"
-            "2. Trigger it on both `push` and `pull_request`, and invoke "
-            "`hashgraph-online/ai-plugin-scanner-action`.\n"
-            "3. Configure `plugin_dir: \".\"`, `mode: scan`, `min_score: 80`, and "
-            "`fail_on_severity: high`."
-        )
-    else:
-        guidance = (
-            "1. Run `pipx run plugin-scanner lint .`.\n"
-            "2. Run `pipx run plugin-scanner verify . --format text`.\n"
-            "3. Fix all critical/high findings and reach a score of at least 80, "
-            "then push the fixes and rerun the workflow."
-        )
+    guidance = (
+        "1. Use the Community Plugins format: "
+        "`- [Name](https://github.com/owner/repo) - description`.\n"
+        "2. Add the entry to the correct section, alphabetically, without duplicates."
+    )
 
     return f"""{COMMENT_MARKER}
 
@@ -186,7 +194,7 @@ def remediation_comment(
 ### How to fix it
 {guidance}
 
-See the repository's [contribution requirements](https://github.com/hashgraph-online/awesome-ai-plugins/blob/main/CONTRIBUTING.md) and [scanner guide](https://github.com/hashgraph-online/awesome-ai-plugins/blob/main/SCANNER_GUIDE.md).
+See the repository's [contribution requirements](https://github.com/hashgraph-online/awesome-ai-plugins/blob/main/CONTRIBUTING.md).
 
 After pushing the changes, this check and comment will update automatically: {run_url}
 """

--- a/scripts/validate-contribution.py
+++ b/scripts/validate-contribution.py
@@ -6,13 +6,12 @@ validator therefore checks the contribution at the same boundary a maintainer
 reviews it:
 
 * only newly added Community Plugins entries are considered;
-* each source repository is public and exposes workflow-based scanner CI; and
-* the workflow is triggered by a push or pull request and invokes the HOL AI
-  Plugin Scanner action.
+* catalog format and discovery failures are hard errors; and
+* maintainer-owned scanner CI is inspected as advisory metadata, not a merge gate.
 
 The workflow that calls this script emits a matrix of source repositories.  A
-follow-up job scans each repository with the same 80-point/high-severity gate
-documented in CONTRIBUTING.md.
+follow-up job scans each repository independently. Scanner absence, findings, or
+outage do not fail the required contribution check.
 """
 
 from __future__ import annotations
@@ -56,6 +55,13 @@ class Contribution:
     owner: str
     repo: str
     description: str
+
+
+@dataclass(frozen=True)
+class ScannerCiInspection:
+    status: str
+    workflow_paths: tuple[str, ...] = ()
+    detail: str = ""
 
 
 @dataclass(frozen=True)
@@ -316,34 +322,75 @@ def workflow_files(owner: str, repo: str) -> list[tuple[str, str]]:
     return files
 
 
-def validate_scanner_ci(contribution: Contribution) -> None:
-    """Require a push/PR workflow that invokes the HOL scanner action."""
+def inspect_scanner_ci(contribution: Contribution) -> ScannerCiInspection:
+    """Detect maintainer scanner CI without treating absence as a hard failure."""
 
     try:
         files = workflow_files(contribution.owner, contribution.repo)
-    except (ValidationError, json.JSONDecodeError) as error:
-        raise ValidationError(
-            f"{contribution.url} does not expose readable GitHub Actions workflows: {error}"
-        ) from error
+    except ValidationError as error:
+        message = str(error)
+        if "not found" in message.lower():
+            return ScannerCiInspection(status="not_detected", detail=message)
+        return ScannerCiInspection(status="unknown", detail=message)
+    except json.JSONDecodeError as error:
+        return ScannerCiInspection(status="unknown", detail=str(error))
 
     scanner_workflows: list[tuple[str, object, list[str]]] = []
+    unreadable = False
     for name, text in files:
-        document = parse_workflow_document(name, text)
+        try:
+            document = parse_workflow_document(name, text)
+        except ValidationError:
+            unreadable = True
+            continue
         references = scanner_steps(document)
         if references:
             scanner_workflows.append((name, document, references))
 
-    if not scanner_workflows:
-        raise ValidationError(
-            f"{contribution.url} must invoke "
-            "hashgraph-online/ai-plugin-scanner-action in .github/workflows"
+    maintained_paths = tuple(
+        name
+        for name, document, _ in scanner_workflows
+        if workflow_has_ci_trigger(document)
+    )
+    if maintained_paths:
+        return ScannerCiInspection(status="maintained", workflow_paths=maintained_paths)
+    if unreadable:
+        return ScannerCiInspection(
+            status="unknown",
+            detail="workflow contents could not be read reliably",
         )
+    return ScannerCiInspection(
+        status="not_detected",
+        workflow_paths=tuple(name for name, _, _ in scanner_workflows),
+    )
 
-    if not any(workflow_has_ci_trigger(document) for _, document, _ in scanner_workflows):
-        names = ", ".join(name for name, _, _ in scanner_workflows)
-        raise ValidationError(
-            f"{contribution.url} scanner workflow ({names}) must run on push or pull_request"
-        )
+
+def malformed_community_plugin_lines(diff: str, head_readme: str) -> list[str]:
+    """Return added Community Plugins bullets that do not match the catalog format."""
+
+    if not diff:
+        return []
+    readme_lines = head_readme.splitlines()
+    malformed: list[str] = []
+    added_line_number = 0
+    for line in diff.splitlines():
+        if line.startswith("@@"):
+            hunk = re.search(r"\+(\d+)", line)
+            added_line_number = int(hunk.group(1)) if hunk else 0
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            content = line[1:].strip()
+            if (
+                current_readme_section(readme_lines, added_line_number) == "Community Plugins"
+                and content.startswith("- [")
+                and README_ENTRY_RE.match(content) is None
+            ):
+                malformed.append(content)
+            added_line_number += 1
+            continue
+        if not line.startswith("-"):
+            added_line_number += 1
+    return malformed
 
 
 def list_open_pull_requests(repository: str, pull_request_number: int | None) -> list[OpenPullRequest]:
@@ -429,6 +476,12 @@ def entries_for_open_pull_request(repository: str, pull_request: OpenPullRequest
             tofile="README.md",
         )
     )
+    malformed = malformed_community_plugin_lines(diff, head_readme)
+    if malformed:
+        raise ValidationError(
+            "Community Plugins entries must use `- [Name](https://github.com/owner/repo) - description`: "
+            + "; ".join(malformed)
+        )
     return get_new_readme_entries_from_diff(diff, base_readme, head_readme)
 
 
@@ -490,24 +543,16 @@ def scan_open_pull_requests(
 
         report_lines.append(f"- **{prefix}**")
         scanner_contributions: list[dict[str, str]] = []
-        scanner_failures: list[str] = []
         for entry in entries:
             contribution = f"{entry.owner}/{entry.repo}"
-            try:
-                validate_scanner_ci(entry)
-            except ValidationError as error:
-                failures.append(
-                    {
-                        "pr_number": pull_request.number,
-                        "repository": contribution,
-                        "error": str(error),
-                    }
-                )
-                scanner_failures.append(f"{contribution}: {error}")
-                report_lines.append(f"  - `{contribution}`: **FAIL** — {error}")
-                continue
-
-            scanner_contributions.append({"owner": entry.owner, "repo": entry.repo})
+            inspection = inspect_scanner_ci(entry)
+            scanner_contributions.append(
+                {
+                    "owner": entry.owner,
+                    "repo": entry.repo,
+                    "scanner_ci": inspection.status,
+                }
+            )
             matrix.append(
                 {
                     "pr_number": pull_request.number,
@@ -515,7 +560,9 @@ def scan_open_pull_requests(
                     "repo": entry.repo,
                 }
             )
-            report_lines.append(f"  - `{contribution}`: scanner CI present; queued for score scan")
+            report_lines.append(
+                f"  - `{contribution}`: scanner CI {inspection.status}; queued for advisory scan"
+            )
 
         results.append(
             {
@@ -523,9 +570,9 @@ def scan_open_pull_requests(
                 "title": pull_request.title,
                 "head_sha": pull_request.head_sha,
                 "author_login": pull_request.author_login,
-                "state": "failure" if scanner_failures else "scan",
+                "state": "scan",
                 "contributions": scanner_contributions,
-                "failure_reasons": scanner_failures,
+                "failure_reasons": [],
             }
         )
 
@@ -535,12 +582,17 @@ def scan_open_pull_requests(
         report_lines.extend(
             [
                 "",
-                f"Scanner CI validation failures: {len(failures)}",
-                "Source repositories must add the HOL AI Plugin Scanner workflow before merge.",
+                f"Catalog validation failures: {len(failures)}",
+                "Malformed catalog changes and discovery failures still block merge.",
             ]
         )
     else:
-        report_lines.extend(["", "All open contribution entries passed scanner CI validation."])
+        report_lines.extend(
+            [
+                "",
+                "Catalog validation passed. Centralized scanner results are advisory.",
+            ]
+        )
 
     report = "\n".join(report_lines) + "\n"
     if matrix_output:
@@ -641,6 +693,17 @@ def main() -> int:
         print(f"ERROR: base ref '{args.base_ref}' is not available", file=sys.stderr)
         return 1
 
+    diff = git("diff", args.base_ref, "--", "README.md")
+    head_readme = README_PATH.read_text(encoding="utf-8") if README_PATH.exists() else ""
+    malformed = malformed_community_plugin_lines(diff, head_readme)
+    if malformed:
+        print("ERROR: malformed Community Plugins entries:", file=sys.stderr)
+        for line in malformed:
+            print(f"  {line}", file=sys.stderr)
+        if args.matrix_output:
+            write_matrix(args.matrix_output, [])
+        return 1
+
     entries = get_new_readme_entries(args.base_ref)
     if not entries:
         print("No new Community Plugins entries found; contribution checks are complete.")
@@ -648,22 +711,14 @@ def main() -> int:
             write_matrix(args.matrix_output, [])
         return 0
 
-    failures = 0
     for entry in entries:
         print(f"Checking {entry.display_name} ({entry.owner}/{entry.repo})...")
-        try:
-            validate_scanner_ci(entry)
-        except ValidationError as error:
-            failures += 1
-            print(f"  FAIL: {error}", file=sys.stderr)
-        else:
-            print("  PASS: scanner CI is present and push/PR-triggered")
+        inspection = inspect_scanner_ci(entry)
+        print(f"  scanner CI {inspection.status}; queued for advisory centralized scan")
 
-    if failures:
-        print(f"\nContribution validation failed for {failures} entr{'y' if failures == 1 else 'ies'}.", file=sys.stderr)
-        return 1
-
-    print(f"\nAll {len(entries)} contribution entr{'y' if len(entries) == 1 else 'ies'} passed.")
+    print(
+        f"\nAll {len(entries)} contribution entr{'y' if len(entries) == 1 else 'ies'} passed catalog validation."
+    )
     if args.matrix_output:
         write_matrix(args.matrix_output, entries)
     return 0

--- a/scripts/validate-contribution.py
+++ b/scripts/validate-contribution.py
@@ -322,6 +322,22 @@ def workflow_files(owner: str, repo: str) -> list[tuple[str, str]]:
     return files
 
 
+def ensure_public_github_repository(contribution: Contribution) -> None:
+    """Fail catalog validation when the source repository is not reachable."""
+
+    url = f"https://api.github.com/repos/{contribution.owner}/{contribution.repo}"
+    try:
+        payload = github_json(url)
+    except ValidationError as error:
+        raise ValidationError(
+            f"{contribution.url} is not a reachable public GitHub repository: {error}"
+        ) from error
+    if not isinstance(payload, dict):
+        raise ValidationError(
+            f"{contribution.url} is not a reachable public GitHub repository"
+        )
+
+
 def inspect_scanner_ci(contribution: Contribution) -> ScannerCiInspection:
     """Detect maintainer scanner CI without treating absence as a hard failure."""
 
@@ -543,8 +559,15 @@ def scan_open_pull_requests(
 
         report_lines.append(f"- **{prefix}**")
         scanner_contributions: list[dict[str, str]] = []
+        catalog_failures: list[str] = []
         for entry in entries:
             contribution = f"{entry.owner}/{entry.repo}"
+            try:
+                ensure_public_github_repository(entry)
+            except ValidationError as error:
+                catalog_failures.append(str(error))
+                report_lines.append(f"  - `{contribution}`: **FAIL** — {error}")
+                continue
             inspection = inspect_scanner_ci(entry)
             scanner_contributions.append(
                 {
@@ -564,15 +587,26 @@ def scan_open_pull_requests(
                 f"  - `{contribution}`: scanner CI {inspection.status}; queued for advisory scan"
             )
 
+        if catalog_failures:
+            failures.extend(
+                {"pr_number": pull_request.number, "error": item}
+                for item in catalog_failures
+            )
+        if catalog_failures:
+            result_state = "failure"
+        elif scanner_contributions:
+            result_state = "scan"
+        else:
+            result_state = "success"
         results.append(
             {
                 "pr_number": pull_request.number,
                 "title": pull_request.title,
                 "head_sha": pull_request.head_sha,
                 "author_login": pull_request.author_login,
-                "state": "scan",
+                "state": result_state,
                 "contributions": scanner_contributions,
-                "failure_reasons": [],
+                "failure_reasons": catalog_failures,
             }
         )
 
@@ -711,10 +745,27 @@ def main() -> int:
             write_matrix(args.matrix_output, [])
         return 0
 
+    catalog_failures = 0
     for entry in entries:
         print(f"Checking {entry.display_name} ({entry.owner}/{entry.repo})...")
+        try:
+            ensure_public_github_repository(entry)
+        except ValidationError as error:
+            catalog_failures += 1
+            print(f"  FAIL: {error}", file=sys.stderr)
+            continue
         inspection = inspect_scanner_ci(entry)
         print(f"  scanner CI {inspection.status}; queued for advisory centralized scan")
+
+    if catalog_failures:
+        print(
+            f"\nContribution validation failed for {catalog_failures} "
+            f"entr{'y' if catalog_failures == 1 else 'ies'}.",
+            file=sys.stderr,
+        )
+        if args.matrix_output:
+            write_matrix(args.matrix_output, [])
+        return 1
 
     print(
         f"\nAll {len(entries)} contribution entr{'y' if len(entries) == 1 else 'ies'} passed catalog validation."

--- a/tests/test-validate-contribution.py
+++ b/tests/test-validate-contribution.py
@@ -89,6 +89,15 @@ class ValidateContributionTests(unittest.TestCase):
             inspection = MODULE.inspect_scanner_ci(contribution())
         self.assertEqual(inspection.status, "unknown")
 
+    def test_missing_source_repository_fails_catalog_validation(self) -> None:
+        with patch.object(
+            MODULE,
+            "github_json",
+            side_effect=MODULE.ValidationError("source repository or workflow directory was not found"),
+        ):
+            with self.assertRaisesRegex(MODULE.ValidationError, "reachable public GitHub repository"):
+                MODULE.ensure_public_github_repository(contribution("missing-plugin"))
+
     def test_malformed_readme_change_still_fails(self) -> None:
         head = (
             "## Community Plugins\n"

--- a/tests/test-validate-contribution.py
+++ b/tests/test-validate-contribution.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts/validate-contribution.py"
+SPEC = importlib.util.spec_from_file_location("validate_contribution", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+Contribution = MODULE.Contribution
+
+
+def contribution(repo: str = "example-plugin") -> Contribution:
+    return Contribution(
+        display_name="Example Plugin",
+        url=f"https://github.com/example/{repo}",
+        owner="example",
+        repo=repo,
+        description="An example plugin.",
+    )
+
+
+MAINTAINED_WORKFLOW = """
+name: Scan
+on:
+  push:
+  pull_request:
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hashgraph-online/ai-plugin-scanner-action@abc123
+"""
+
+UNRELATED_WORKFLOW = """
+name: CI
+on:
+  push:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+"""
+
+
+class ValidateContributionTests(unittest.TestCase):
+    def test_repository_without_scanner_ci_is_valid_and_enters_scan_matrix(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            matrix_path = Path(directory) / "matrix.json"
+            with patch.object(MODULE, "workflow_files", return_value=[]):
+                inspection = MODULE.inspect_scanner_ci(contribution())
+                self.assertEqual(inspection.status, "not_detected")
+                MODULE.write_matrix(matrix_path, [contribution()])
+            payload = json.loads(matrix_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                payload,
+                [{"owner": "example", "repo": "example-plugin"}],
+            )
+
+    def test_repository_with_scanner_ci_is_marked_maintained(self) -> None:
+        with patch.object(
+            MODULE,
+            "workflow_files",
+            return_value=[("scan.yml", MAINTAINED_WORKFLOW)],
+        ):
+            inspection = MODULE.inspect_scanner_ci(contribution())
+        self.assertEqual(inspection.status, "maintained")
+        self.assertEqual(inspection.workflow_paths, ("scan.yml",))
+
+    def test_unreadable_workflows_are_unknown(self) -> None:
+        with patch.object(
+            MODULE,
+            "workflow_files",
+            return_value=[("scan.yml", ":\n- :")],
+        ), patch.object(
+            MODULE,
+            "parse_workflow_document",
+            side_effect=MODULE.ValidationError("invalid yaml"),
+        ):
+            inspection = MODULE.inspect_scanner_ci(contribution())
+        self.assertEqual(inspection.status, "unknown")
+
+    def test_malformed_readme_change_still_fails(self) -> None:
+        head = (
+            "## Community Plugins\n"
+            "- [Broken Plugin](https://example.com/not-github) - not a github repo\n"
+        )
+        diff = (
+            "@@ -1,1 +1,2 @@\n"
+            " ## Community Plugins\n"
+            "+- [Broken Plugin](https://example.com/not-github) - not a github repo\n"
+        )
+        malformed = MODULE.malformed_community_plugin_lines(diff, head)
+        self.assertEqual(len(malformed), 1)
+
+
+class PublishOpenPrChecksTests(unittest.TestCase):
+    def setUp(self) -> None:
+        publisher_path = (
+            Path(__file__).resolve().parents[1] / "scripts/publish-open-pr-checks.py"
+        )
+        spec = importlib.util.spec_from_file_location("publish_open_pr_checks", publisher_path)
+        assert spec and spec.loader
+        self.publisher = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = self.publisher
+        spec.loader.exec_module(self.publisher)
+
+    def test_check_succeeds_with_missing_ci_and_includes_optional_guidance(self) -> None:
+        result = {
+            "pr_number": 12,
+            "state": "scan",
+            "title": "Add example plugin",
+            "author_login": "octocat",
+        }
+        conclusion, title, summary = self.publisher.check_summary(result, {12: []})
+        self.assertEqual(conclusion, "success")
+        self.assertEqual(title, "scan unavailable")
+        self.assertIn("advisory", summary.lower())
+        comment = self.publisher.remediation_comment(
+            result,
+            conclusion,
+            title,
+            summary,
+            "https://example.test/run",
+        )
+        self.assertIn("Contribution check passed", comment)
+        self.assertNotIn("needs updates before it can be merged", comment)
+        self.assertNotIn("must invoke", comment)
+
+    def test_check_succeeds_when_advisory_scan_fails(self) -> None:
+        result = {
+            "pr_number": 12,
+            "state": "scan",
+            "title": "Add example plugin",
+            "author_login": "octocat",
+        }
+        conclusion, title, summary = self.publisher.check_summary(
+            result,
+            {12: ["failure"]},
+        )
+        self.assertEqual(conclusion, "success")
+        self.assertEqual(title, "scan findings")
+        self.assertIn("advisory", summary.lower())
+        comment = self.publisher.remediation_comment(
+            result,
+            conclusion,
+            title,
+            summary,
+            "https://example.test/run",
+        )
+        self.assertNotIn("needs updates before it can be merged", comment)
+
+    def test_scan_passed_title_is_used_when_jobs_succeed(self) -> None:
+        conclusion, title, _summary = self.publisher.check_summary(
+            {
+                "pr_number": 12,
+                "state": "scan",
+                "title": "Add example plugin",
+            },
+            {12: ["success", "success"]},
+        )
+        self.assertEqual(conclusion, "success")
+        self.assertEqual(title, "scan passed")
+
+    def test_comment_updater_replaces_the_prior_marker_comment(self) -> None:
+        calls: list[tuple[str, str]] = []
+
+        def fake_github_api(_repository: str, path: str, _token: str, **kwargs: object) -> object:
+            calls.append((str(kwargs.get("method", "GET")), path))
+            if path.startswith("/issues/") and path.endswith("/comments"):
+                return {"id": 99}
+            return {}
+
+        result = {
+            "pr_number": 12,
+            "state": "scan",
+            "title": "Add example plugin",
+            "author_login": "octocat",
+        }
+        with patch.object(self.publisher, "github_api", side_effect=fake_github_api), patch.object(
+            self.publisher,
+            "list_issue_comments",
+            return_value=[
+                {
+                    "id": 44,
+                    "body": "<!-- awesome-ai-plugins-contribution-gate -->\nRequired scanner CI is missing.",
+                }
+            ],
+        ):
+            self.publisher.upsert_remediation_comment(
+                "hashgraph-online/awesome-ai-plugins",
+                result,
+                "success",
+                "scan unavailable",
+                "HOL centralized scan could not run.",
+                "https://example.test/run",
+                "token",
+            )
+        self.assertEqual(calls, [("PATCH", "/issues/comments/44")])
+        self.assertNotIn(("POST", "/issues/12/comments"), calls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Make maintainer-owned scanner CI optional for Community Plugin listings.
- Keep HOL's centralized scan of valid new source repositories. Scanner absence, findings, or outage no longer fail the required contribution check.
- Update bot comments and checks in place with `scan passed`, `scan findings`, or `scan unavailable`. Catalog format and discovery failures still fail.
- Document that scanner CI is optional and that projects without it remain eligible with a 10% trust-score reduction.

## Testing
- `python3 tests/test-validate-contribution.py`
- `python3 tests/test-sync-scanner-action.py`
