### PR TITLE
Add dsh-config-manager to DeepSeek Harness Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 
 ## Contents
 
+- [dsh-config-manager](https://github.com/xiajiajun516/dsh-config-manager) - Backup, restore, export, import, migrate and sync your complete DeepSeek Harness (DSH) configuration — settings, model providers, plugins, MCP servers, skills, agent presets and workspaces — and restore your whole environment on a new machine with one click.
 - [MCP Migration Check](https://github.com/AlpayC/mcp-migration-check) - Deterministic MCP 2026-07-28 migration checker with an agent skill, CLI, GitHub Action, and hosted web probe powered by one rule engine.
 - [Start Here](#start-here)
 - [Official Plugins](#official-plugins)


### PR DESCRIPTION
## What

Add [dsh-config-manager](https://github.com/xiajiajun516/dsh-config-manager) to the **DeepSeek Harness Plugins** section of the README, as invited in the listing request.

**dsh-config-manager** is a Cordis plugin for DeepSeek Harness (DSH) that provides backup, restore, export/import, migration, remote sync (git/WebDAV), encrypted snapshots, and a configuration marketplace — all 13 DSH config surfaces (settings, model providers, plugins, MCP servers, skills, agent presets, workspaces, credentials, sessions, etc.) included.

- Single entry in the (previously empty) DeepSeek Harness Plugins section, matching the `README_ENTRY_RE` format and alphabetical order
- Cross-repo close: Closes xiajiajun516/dsh-config-manager#3

## Checklist

- [x] Entry follows the format shown in CONTRIBUTING.md
- [x] Alphabetical order within the section (only entry)
- [x] Repository is public and reachable