### PR TITLE
Add AI Video Transcriber

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [AgentPack](https://github.com/vishal2612200/agentpack) - Ranks repo context for Codex with likely files, skill recommendations, agent rules, commands, warnings, and compact task-focused packs before editing.
 - [Agentry Observability](https://github.com/fr33dr4g0n/agentry-public) - Agent-native product analytics, error logging, and deploy attribution for coding agents through one HTTP API.
 - [AgiFlow](https://github.com/AgiFlow/ai-plugin) - Project management workflows for AI coding agents with planning, grooming, task execution, review, and AgiFlow MCP integration.
+- [AI Video Transcriber](https://github.com/wendy7756/AI-Video-Transcriber) - Transcribe and summarize videos, podcasts, and local media via a Codex plugin, Claude Code skill, and MCP server.
 - [AIBoarding](https://github.com/gustavo-meilus/aiboarding) - Generate, maintain, compress, and audit standard AI-agent onboarding files with AGENTS.md, CLAUDE.md, drift tracking, and lifecycle hooks.
 - [Alcove](https://github.com/epicsagas/alcove) - Local-first MCP server for private project docs with hybrid BM25+vector search, tree-sitter code indexing, and automated linting for team-wide documentation standards.
 - [Anchor](https://github.com/biefan/anchor) - Engineering discipline pack for Claude Code & Codex CLI with task-scope locking, anti-drift braking, condition-based codex review, project-CLAUDE.md pitfall writeback, and PreToolUse hooks that block irreversible bash patterns.


### PR DESCRIPTION
## Summary

- Adds [AI Video Transcriber](https://github.com/wendy7756/AI-Video-Transcriber) to **Community Plugins → Development & Workflow**, alphabetically after AgiFlow and before AIBoarding.

## What it is

Open-source video/podcast transcriber with a Codex App plugin (`.codex-plugin/plugin.json`), a Claude Code skill, and an optional MCP server (`transcribe_video`).

## Verification

- Repository is active (recent commits/releases).
- Codex plugin, Claude skill, and MCP install steps are documented in the project README.
- Tested locally: CLI `transcribe.py`, Codex plugin skill, and `mcp_server.py --selftest`.

Prompted by [wendy7756/AI-Video-Transcriber#51](https://github.com/wendy7756/AI-Video-Transcriber/issues/51).


Made with [Cursor](https://cursor.com)