### PR TITLE
feat(ci): comment when listing PRs omit optional scanner CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,8 +94,10 @@ advisory and do not block a valid listing.
 Existing open pull requests are covered by the scheduled and manually
 dispatchable `.github/workflows/sweep-open-prs.yml` workflow. It reviews each
 PR's exact README base/head revisions without executing fork code, queues an
-advisory scan, and publishes the result on each PR head. Reruns update the
-existing bot comment and check in place.
+advisory scan, and publishes the result on each PR head. When the source
+repository has no scanner CI, the bot still comments: listing can merge, adding
+the action is optional, and the comment explains the trust-score benefit.
+Reruns update the existing bot comment and check in place.
 
 Use scanner outputs as evidence for maintainers/reviewers:
 - Structural lint results

--- a/scripts/publish-open-pr-checks.py
+++ b/scripts/publish-open-pr-checks.py
@@ -148,6 +148,45 @@ def list_issue_comments(repository: str, number: int, token: str) -> list[dict[s
         page += 1
 
 
+def missing_scanner_ci_repos(result: dict[str, object]) -> list[str]:
+    """Return owner/repo pairs whose source repository has no scanner CI."""
+
+    contributions = result.get("contributions")
+    if not isinstance(contributions, list):
+        return []
+    missing: list[str] = []
+    for item in contributions:
+        if not isinstance(item, dict):
+            continue
+        if item.get("scanner_ci") != "not_detected":
+            continue
+        owner = item.get("owner")
+        repo = item.get("repo")
+        if isinstance(owner, str) and isinstance(repo, str) and owner and repo:
+            missing.append(f"{owner}/{repo}")
+    return missing
+
+
+def optional_scanner_ci_guidance(repos: list[str]) -> str:
+    """Explain that scanner CI is optional and why maintainers should still add it."""
+
+    listed = ", ".join(f"`{item}`" for item in repos)
+    subject = listed if listed else "the source repository"
+    return (
+        "\n\n### Optional: add scanner CI\n"
+        f"This listing can merge without it. HOL still scans {subject} independently.\n\n"
+        "We recommend adding `hashgraph-online/ai-plugin-scanner-action` under "
+        "`.github/workflows/` on `push` and `pull_request` so that:\n"
+        "- the listing keeps the **full trust score** (without maintainer CI it stays "
+        "eligible, with a 10% trust-score reduction);\n"
+        "- new commits stay continuously checked for secrets, dangerous hooks, and "
+        "supply-chain issues;\n"
+        "- findings can appear in GitHub code scanning.\n\n"
+        "See [CONTRIBUTING.md](https://github.com/hashgraph-online/awesome-ai-plugins/blob/main/CONTRIBUTING.md) "
+        "and [SCANNER_GUIDE.md](https://github.com/hashgraph-online/awesome-ai-plugins/blob/main/SCANNER_GUIDE.md).\n"
+    )
+
+
 def remediation_comment(
     result: dict[str, object],
     conclusion: str,
@@ -161,15 +200,16 @@ def remediation_comment(
     mention = f"@{author_login}" if isinstance(author_login, str) and GITHUB_LOGIN_RE.fullmatch(author_login) else "the contributor"
     if conclusion == "success":
         optional_guidance = ""
+        missing = missing_scanner_ci_repos(result)
+        if missing:
+            optional_guidance += optional_scanner_ci_guidance(missing)
         if "scan findings" in check_title:
-            optional_guidance = (
-                "\n\nHOL's centralized scan reported findings. This does not block listing. "
-                "Optional scanner CI in the source repository receives the full trust score; "
-                "projects without it remain eligible with a 10% trust-score reduction.\n"
+            optional_guidance += (
+                "\nHOL's centralized scan reported findings. This does not block listing.\n"
             )
         elif "scan unavailable" in check_title:
-            optional_guidance = (
-                "\n\nHOL's centralized scan could not run. This does not block listing.\n"
+            optional_guidance += (
+                "\nHOL's centralized scan could not run. This does not block listing.\n"
             )
         return (
             f"{COMMENT_MARKER}\n\n"
@@ -223,7 +263,11 @@ def upsert_remediation_comment(
         ),
         None,
     )
-    if conclusion == "success" and existing is None:
+    if (
+        conclusion == "success"
+        and existing is None
+        and not missing_scanner_ci_repos(result)
+    ):
         return
 
     body = remediation_comment(result, conclusion, check_title, summary, run_url)

--- a/tests/test-validate-contribution.py
+++ b/tests/test-validate-contribution.py
@@ -129,6 +129,9 @@ class PublishOpenPrChecksTests(unittest.TestCase):
             "state": "scan",
             "title": "Add example plugin",
             "author_login": "octocat",
+            "contributions": [
+                {"owner": "example", "repo": "plugin", "scanner_ci": "not_detected"},
+            ],
         }
         conclusion, title, summary = self.publisher.check_summary(result, {12: []})
         self.assertEqual(conclusion, "success")
@@ -142,6 +145,11 @@ class PublishOpenPrChecksTests(unittest.TestCase):
             "https://example.test/run",
         )
         self.assertIn("Contribution check passed", comment)
+        self.assertIn("Optional: add scanner CI", comment)
+        self.assertIn("can merge without it", comment)
+        self.assertIn("full trust score", comment)
+        self.assertIn("10% trust-score reduction", comment)
+        self.assertIn("`example/plugin`", comment)
         self.assertNotIn("needs updates before it can be merged", comment)
         self.assertNotIn("must invoke", comment)
 
@@ -216,6 +224,72 @@ class PublishOpenPrChecksTests(unittest.TestCase):
             )
         self.assertEqual(calls, [("PATCH", "/issues/comments/44")])
         self.assertNotIn(("POST", "/issues/12/comments"), calls)
+
+    def test_comment_is_posted_when_scanner_ci_is_missing(self) -> None:
+        calls: list[tuple[str, str]] = []
+
+        def fake_github_api(_repository: str, path: str, _token: str, **kwargs: object) -> object:
+            calls.append((str(kwargs.get("method", "GET")), path))
+            if path == "/issues/12/comments":
+                return {"id": 99}
+            return {}
+
+        result = {
+            "pr_number": 12,
+            "state": "scan",
+            "title": "Add example plugin",
+            "author_login": "octocat",
+            "contributions": [
+                {"owner": "example", "repo": "plugin", "scanner_ci": "not_detected"},
+            ],
+        }
+        with patch.object(self.publisher, "github_api", side_effect=fake_github_api), patch.object(
+            self.publisher,
+            "list_issue_comments",
+            return_value=[],
+        ):
+            self.publisher.upsert_remediation_comment(
+                "hashgraph-online/awesome-ai-plugins",
+                result,
+                "success",
+                "scan passed",
+                "Catalog validation passed.",
+                "https://example.test/run",
+                "token",
+            )
+        self.assertEqual(calls, [("POST", "/issues/12/comments")])
+
+    def test_success_without_missing_ci_does_not_post_a_new_comment(self) -> None:
+        calls: list[tuple[str, str]] = []
+
+        def fake_github_api(_repository: str, path: str, _token: str, **kwargs: object) -> object:
+            calls.append((str(kwargs.get("method", "GET")), path))
+            return {}
+
+        result = {
+            "pr_number": 12,
+            "state": "scan",
+            "title": "Add example plugin",
+            "author_login": "octocat",
+            "contributions": [
+                {"owner": "example", "repo": "plugin", "scanner_ci": "maintained"},
+            ],
+        }
+        with patch.object(self.publisher, "github_api", side_effect=fake_github_api), patch.object(
+            self.publisher,
+            "list_issue_comments",
+            return_value=[],
+        ):
+            self.publisher.upsert_remediation_comment(
+                "hashgraph-online/awesome-ai-plugins",
+                result,
+                "success",
+                "scan passed",
+                "Catalog validation passed.",
+                "https://example.test/run",
+                "token",
+            )
+        self.assertEqual(calls, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Post an advisory bot comment when a listing pull request's source repository has no scanner CI.
- Keep the contribution check green: the comment says listing can merge without the action, recommends adding it, and explains the 10% trust-score reduction.
- Skip a new comment when scanner CI is already maintained and catalog validation passed.

## Testing
- `python3 tests/test-validate-contribution.py`
