### PR TITLE
Add deja to Kimi and DeepSeek Harness plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,8 @@ Depending on the plugin version, a repository can expose `kimi.plugin.json` or
 plugins here in alphabetical order. See the [official Kimi plugin documentation](https://github.com/MoonshotAI/kimi-code/blob/main/docs/en/customization/plugins.md)
 before submitting.
 
+- [deja](https://github.com/vshulcz/deja-vu) - Recalls the sessions the other coding agents on the machine already wrote to disk, including work from before it was installed, through MCP tools, a `/deja:recall` command and recall on every prompt.
+
 ### DeepSeek Harness Plugins
 
 DeepSeek Harness (DSH) plugins are Cordis modules or npm packages that expose a
@@ -355,6 +357,8 @@ community plugins here in alphabetical order. See the [official DeepSeek Harness
 plugin tutorial](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/cordis-tutorial/01-first-plugin.md)
 and the [`dsh-plugin` community topic](https://github.com/topics/dsh-plugin) before
 submitting a repository.
+
+- [dsh-deja](https://github.com/vshulcz/deja-vu/tree/main/extensions/dsh) - Brings the session history of nineteen other coding agents into DeepSeek Harness: recall, session digest and per-file history tools over a local index, plus optional automatic recall.
 
 ## Formats & Development
 

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ plugin tutorial](https://github.com/deepseek-ai/deepseek-harness/blob/master/doc
 and the [`dsh-plugin` community topic](https://github.com/topics/dsh-plugin) before
 submitting a repository.
 
-- [dsh-deja](https://github.com/vshulcz/deja-vu/tree/main/extensions/dsh) - Brings the session history of nineteen other coding agents into DeepSeek Harness: recall, session digest and per-file history tools over a local index, plus optional automatic recall.
+- [dsh-deja](https://github.com/vshulcz/deja-vu) - Brings the session history of nineteen other coding agents into DeepSeek Harness: recall, session digest and per-file history tools over a local index, plus optional automatic recall.
 
 ## Formats & Development
 


### PR DESCRIPTION
Two entries, following the per-section rules in CONTRIBUTING.

**Kimi Plugins — deja.** `kimi.plugin.json` sits at the repository root, which is the only reason that file is there: `/plugins install https://github.com/vshulcz/deja-vu` is the tested flow. The manifest declares the MCP server, a skill, the `/deja:recall` command and a `UserPromptSubmit` hook. deja indexes the session transcripts twenty coding agents already write to disk — Claude Code, Codex, Cursor, opencode, Zed and others — including sessions from before it was installed, and answers from them locally: BM25 over the transcripts, no model and no embeddings, credentials redacted as the index is built.

**DeepSeek Harness Plugins — dsh-deja.** Published on npm as `dsh-deja`, installed with `dsh plugin add dsh-deja`, and `package.json` declares `dsh.bundle.patch` pointing at the cordis patch. Source lives in the same repository under `extensions/dsh`.

Both are MIT and maintained in one repository, `vshulcz/deja-vu`.

Ran `scripts/check-alphabetical.py README.md` before opening this: all sections sorted.
