### PR TITLE
Add CloudBase AI Toolkit (MCP server + Skills for Tencent CloudBase)

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [CarsXE](https://github.com/carsxe/carsxe-codex-plugin) - Decode VINs, license plates, market value, vehicle history, recalls, liens, OBD codes, and more via the CarsXE API.
 - [Chrome DevTools](https://github.com/win4r/chrome-devtools-codex-plugin) - One-click Codex plugin wrapper for chrome-devtools-mcp.
 - [claude-math](https://github.com/vladimirrott/claude-math) - Emit mathematics as copy- and search-safe inline Unicode (∑, ≤, ℝ, x², matrices, set-builder) instead of LaTeX so equations stay legible in the Codex TUI, terminals, and Claude Code.
+- [CloudBase AI Toolkit](https://github.com/TencentCloudBase/CloudBase-AI-Toolkit) - Backend for AI coding agents on Tencent CloudBase — database, auth, and functions via Plugin, Skills & MCP.
 - [Codex Be Serious](https://github.com/lulucatdev/codex-be-serious) - Enforce formal, textbook-grade written register across all agent output.
 - [Codex Mem](https://github.com/2kDarki/codex-mem) - Automatically capture, compress, and inject session context back into future Codex sessions.
 - [Codex Obsidian](https://github.com/greg-asher/codex-obsidian) - Local Obsidian note and vault workflows through the official desktop `obsidian` CLI.


### PR DESCRIPTION
## What

Add [CloudBase AI Toolkit](https://github.com/TencentCloudBase/CloudBase-AI-Toolkit) to the **Tools & Integrations** section (alphabetical order).

- **Repo:** https://github.com/TencentCloudBase/CloudBase-AI-Toolkit (1k+ stars, official Tencent CloudBase project)
- **Docs:** https://docs.cloudbase.net/ai/cloudbase-ai-toolkit/
- **What it does:** Backend for AI coding agents on Tencent CloudBase — database, auth, and cloud functions managed via Plugins, Skills & MCP. Works with Codex, Claude Code, Cursor, and other AI coding agents.

## Format

Follows CONTRIBUTING format: `- [Name](url) - one sentence description`.

## Verification

- [x] Entry added to the correct section (Tools & Integrations)
- [x] Alphabetical order maintained
- [x] No duplicate entry