### PR TITLE
Add Engramory to DeepSeek Harness Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 ## Contents
 
 - [dsh-config-manager](https://github.com/xiajiajun516/dsh-config-manager) - Backup, restore, export, import, migrate and sync your complete DeepSeek Harness (DSH) configuration — settings, model providers, plugins, MCP servers, skills, agent presets and workspaces — and restore your whole environment on a new machine with one click.
+- [Engramory](https://github.com/tinqiao-oss/engramory) - Curated, file-based long-term memory for DSH agents — plain markdown notes in one store shared across hosts, with the index size cap enforced as a monotonic `ctx.tools.guard()` refusal rather than a reminder. Install: `dsh plugin --profile <name> add dsh-engramory`.
 - [MCP Migration Check](https://github.com/AlpayC/mcp-migration-check) - Deterministic MCP 2026-07-28 migration checker with an agent skill, CLI, GitHub Action, and hosted web probe powered by one rule engine.
 - [Start Here](#start-here)
 - [Official Plugins](#official-plugins)


### PR DESCRIPTION
Adds **Engramory** to the DeepSeek Harness Plugins section — the first entry there. Submitted at @zerocodefast's invitation in tinqiao-oss/engramory#10, under the optional-scanner-CI policy from #127.

### Entry

- Repository: https://github.com/tinqiao-oss/engramory — public, MIT, active
- Section: Community Plugins → DeepSeek Harness Plugins
- npm package: `dsh-engramory` (0.2.3), published from `adapters/dsh/plugin/`

### The DSH contract, per CONTRIBUTING's "DeepSeek Harness submissions"

- **`apply(ctx)` entry point** — `adapters/dsh/plugin/index.js`
- **installable `dsh.bundle` in `package.json`** — the published package declares `dsh.bundle.patch → ./cordis.patch.yml` and ships that file; the repo root carries the same bundle as a discovery manifest (`private: true`, never published from the root) pointing at `./adapters/dsh/plugin/cordis.patch.yml`
- **install command in the repository's README** — `dsh plugin --profile <name> add dsh-engramory`
- **no Codex `.codex-plugin/plugin.json`**, as the DSH exemption allows

What it does, briefly: a curation protocol for file-based agent memory — plain markdown notes, one store shared across hosts, and a hard cap on the always-loaded index. On dsh the cap is a `ctx.tools.guard()` refusal (monotonic, so no later listener can turn it back into an allow) rather than a reminder the agent has to remember to honour, and the skill is registered at runtime through dsh's skill registry instead of depending on files landing in one of the five scanned skill roots.

### Verification

Both required checks run clean locally against `upstream/main`:

```
$ python scripts/check-alphabetical.py README.md
OK:   'DeepSeek Harness Plugins' (1 items)
All sections are alphabetically sorted.

$ python scripts/validate-contribution.py --base-ref upstream/main
Checking Engramory (tinqiao-oss/engramory)...
  scanner CI not_detected; queued for advisory centralized scan
All 1 contribution entry passed catalog validation.
```

Activation is verified on real dsh builds (0.2.1+; 0.2.0 installed but never activated — our own issue #8), the plugin has tests and CI in the source repo, and it has no `exec`, `eval`, install script, outbound network, or environment reads.

No HOL scanner CI in the source repo, so the 10% trust-score reduction applies. Understood and accepted — thank you for making it optional rather than requiring a manifest that would have misdescribed the project.

### One unrelated nit, since I hit it while validating

`scripts/validate-contribution.py`'s `git()` helper calls `subprocess.run(..., text=True)` without `encoding=`, so on Windows with a non-UTF-8 default code page (e.g. cp936) it dies as soon as the diff contains a non-ASCII byte — and the README is full of em dashes:

```
UnicodeDecodeError: 'gbk' codec can't decode byte 0x94 in position 424: illegal multibyte sequence
AttributeError: 'NoneType' object has no attribute 'strip'
```

`PYTHONUTF8=1` is the workaround (that's how the clean run above was produced); `encoding="utf-8"` on those subprocess calls would fix it outright for any Windows contributor running the local preflight. Ubuntu CI is unaffected. Happy to send it as a separate PR if that's useful.
