### PR TITLE
Add Azure Cosmos DB Agent Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Apple Productivity](https://github.com/matk0shub/apple-productivity-mcp) - Local Apple Calendar and Reminders tooling for macOS with Codex plugin adapters.
 - [AutoCAD Tianzheng Tools](https://github.com/summer521521/AutoCAD_Tianzheng_plugin) - Connects Codex to AutoCAD and Tianzheng HVAC through a local MCP server for DWG-aware HVAC drawing inspection and workflow automation.
 - [AxonFlow](https://github.com/getaxonflow/axonflow-codex-plugin) - Runtime governance for Codex with policy enforcement on terminal commands, advisory checks for non-terminal tools via skills, PII/secret detection, and compliance-grade audit trails. Self-hosted via Docker.
+- [Azure Cosmos DB Agent Kit](https://github.com/AzureCosmosDB/cosmosdb-agent-kit) - Azure Cosmos DB best-practice skills and MCP tooling for Codex, Claude Code, Cursor, Gemini CLI, Grok Build, Kimi Code, GitHub Copilot, and other Agent Skills-compatible assistants.
 - [Bitbucket CLI](https://github.com/avivsinai/bitbucket-cli) - Manage Bitbucket repos, PRs, branches, issues, webhooks, and pipelines for Data Center and Cloud.
 - [Cadence Code](https://github.com/michael-L-i/cadence-code) - Fully local voice conversations for Claude Code, Codex, Cursor, and Antigravity on Apple Silicon, with selectable MLX speech and transcription models.
 - [Call-E](https://github.com/CALLE-AI/call-e-integrations) - Plan, run, and inspect Call-E phone call workflows from Codex through the calle CLI.


### PR DESCRIPTION
Adds the Azure Cosmos DB Agent Kit to the alphabetized **Tools & Integrations** registry section.

The Agent Kit provides Azure Cosmos DB best-practice skills and MCP tooling, with manifests for Codex, Claude Code, Cursor, Gemini CLI, Grok Build, Kimi Code, and GitHub Copilot compatibility.

Source: https://github.com/AzureCosmosDB/cosmosdb-agent-kit

## Validation

- `python scripts/validate-contribution.py --base-ref origin/main`
- `python scripts/check-alphabetical.py`
- All 20 repository tests passed when run directly
- `git diff --check`