### PR TITLE
Fix marketplace sync checks for fork pull requests

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -23,18 +23,31 @@ jobs:
     name: Sync marketplace artifacts with README
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout writable branch
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.head_ref || github.ref_name }}
+      - name: Checkout fork pull request
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - name: Regenerate and commit if changed
+        env:
+          IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
         run: |
           python3 scripts/generate_plugins_json.py
           if ! git diff --quiet -- plugins.json .agents/plugins/marketplace.json; then
-            echo "::notice::marketplace artifacts were out of sync — auto-committing"
+            if [ "$IS_FORK_PR" = "true" ]; then
+              echo "::notice::fork PR changed README; generated marketplace artifacts will sync automatically after merge"
+              git diff --check -- plugins.json .agents/plugins/marketplace.json
+              exit 0
+            fi
+
+            echo "::notice::marketplace artifacts were out of sync; auto-committing"
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add plugins.json .agents/plugins/marketplace.json


### PR DESCRIPTION
## Problem

The `Sync marketplace artifacts` workflow currently checks out `${{ github.head_ref }}` from `hashgraph-online/awesome-ai-plugins`. For pull requests opened from forks, that branch exists only in the contributor's fork, so `actions/checkout` fails before the generator can run. This produced a false red check on external submission #162 even though its alphabetical and contribution validation both passed.

## Fix

- Preserve the existing writable-branch behavior for pushes and same-repository PRs.
- For fork PRs, use the normal pull-request checkout so the proposed README can be validated without trying to fetch a nonexistent upstream branch.
- Run the marketplace generator for fork PRs, but do not attempt to push generated artifacts back to an external fork. Instead, verify the generated diff is clean and let the existing `main` push workflow synchronize artifacts immediately after merge.

This removes a recurring conversion blocker for external Registry contributors without granting fork workflows write access or weakening contribution validation.