### PR TITLE
Add 2718lab DevKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 
 <!-- pinned -->
 
+- [2718lab DevKit](https://github.com/2718labs/2718lab-devkit) - Codex-first local MCP server and skill bundle for deterministic project intelligence, durable workflow orchestration, and reusable engineering tools.
 - [A Team](https://github.com/RBraga01/a-team) - Universal multi-agent infrastructure with 25 specialist agents, 16 enforced workflow skills, and a lead orchestrator for Claude Code, Codex CLI, Cursor, and OpenCode.
 - [Aegis](https://github.com/GanyuanRan/Aegis) - An agentic skills framework & software development methodology that works: planning, TDD, debugging, and collaboration workflows.
 - [Agency Continuity Audit](https://github.com/revertcreations/agency-continuity-audit) - Read-only audit that distinguishes durable agent goals, state, corrections, restart evidence, authority boundaries, scheduler claims, and commercial proof from self-reported health.


### PR DESCRIPTION
## Summary

- Adds 2718lab DevKit to **Community Plugins → Development & Workflow**.
- Source: https://github.com/2718labs/2718lab-devkit
- 2718lab DevKit provides a Codex-first local MCP server and skill bundle for deterministic project intelligence and durable workflow orchestration.

## Verification

- Confirmed the source repository is public, active, and has a current default branch.
- Ran `python scripts/check-alphabetical.py README.md` successfully.
- Ran `python scripts/validate-contribution.py --base-ref upstream/main` successfully (1 contribution passed).
- Confirmed the repository URL appears exactly once in the catalog.