### PR TITLE
Add pstack for Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [PR Storyteller](./plugins/mturac/pr-storyteller) - PR title + body + test plan from commits and diff vs base branch.
 - [Praxis](https://github.com/ouonet/praxis) - Intent-driven workflow skills for coding agents: describe what done looks like, not the steps. Triage-first design keeps token costs low across design, TDD, debug, review, and release.
 - [Project Autopilot](https://github.com/AlexMi64/codex-project-autopilot) - Turn an idea into a structured project workflow with planning, execution, verification, and handoff.
+- [pstack for Codex](https://github.com/Aqua-123/pstack-for-codex) - Codex-native engineering workflows derived from pstack, with 45 explicit skills and 23 Poteto Mode playbooks.
 - [Quality Engineering Skills](https://github.com/RBraga01/Quality-Engineering-Skills) - 22 structured quality engineering skills for automotive and manufacturing: ISO 9001, IATF 16949, AIAG-VDA FMEA, VDA 6.3, PPAP, APQP, SPC, MSA.
 - [RAG Reviewer](https://github.com/mimfort/rag_for_git) - Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex.
 - [Registry Broker](https://github.com/hashgraph-online/registry-broker-codex-plugin) - Delegate tasks to specialist AI agents via the HOL Registry, plan, find, summon, and recover sessions.


### PR DESCRIPTION
## Summary
- Add [pstack for Codex](https://github.com/Aqua-123/pstack-for-codex) to **Community Plugins → Development & Workflow** (alphabetical, after Project Autopilot).
- Codex-native marketplace plugin with 45 explicit skills and 23 Poteto Mode playbooks for deliberate engineering workflows.

## Category
Community Plugins / Development & Workflow

## Verification
- Install: `codex plugin marketplace add Aqua-123/pstack-for-codex` then `codex plugin add pstack-for-codex@pstack-for-codex-local`
- Repo is active and public; install docs are in the project README.
- Requested via https://github.com/Aqua-123/pstack-for-codex/issues/1

## Test plan
- [ ] Confirm entry format matches CONTRIBUTING.md
- [ ] Confirm alphabetical placement in Development & Workflow
- [ ] Confirm link resolves to https://github.com/Aqua-123/pstack-for-codex


Made with [Cursor](https://cursor.com)