### PR TITLE
Add coffee-paladin

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex TUI Proof](https://github.com/bnc4vk/codex-tui-proof) - Visually validate real local terminal UIs in Codex's in-app browser with screenshots and session evidence.
 - [Codex Usage and Resets](https://github.com/joelfarthing/codex-usage-and-resets) - Turns Codex usage into planning facts with linear pace, projected exhaustion, banked-reset expirations, and conservative unexpected-reset detection.
 - [Commit Narrator](./plugins/mturac/commit-narrator) - Generate semantic commit message from staged diff, including the _why_.
+- [coffee-paladin](https://github.com/pawelkwaczynski/coffee-paladin) - Thermal guard for Apple Silicon: pauses hot jobs before the Mac throttles and gates Claude Code, Codex and Gemini CLI before heavy commands.
 - [Context Guard](https://github.com/GreenLv/codex-context-guard) - Preserves authoritative requirements and verification evidence across long-running Codex tasks and context compaction.
 - [Cover My Repo](https://github.com/sjh9714/cover-my-repo) - Designs three checked GitHub social preview cards with Codex or Cursor, then renders them locally with Chrome.
 - [debt-ops](https://github.com/bcanfield/agentic-tech-debt) - Catches AI-introduced tech debt at write-time: hooks log every deferral to a registry in your repo and a review skill ranks paydown by file churn.


### PR DESCRIPTION
coffee-paladin is a thermal guard for Apple Silicon Macs. When the chip gets too hot it pauses the heavy job with SIGSTOP and resumes it once the machine cools, so long work survives the heat instead of being killed by it. It also gates Claude Code, Codex CLI and Gemini CLI before heavy commands, and keeps the readings from before a hard shutdown for a repair report.

Repository: https://github.com/pawelkwaczynski/coffee-paladin
License: MIT. macOS 14+, Apple Silicon. No sudo, no kernel extension, no root daemon.

Added under Development & Workflow in alphabetical order. Opened at the maintainers' invitation in pawelkwaczynski/coffee-paladin#1.