### PR TITLE
docs: add SandBase Codex plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [River Review](https://github.com/s977043/river-review) - Versioned Skill Registry of code-review skills driven by a perspective-based review agent (code, security, performance, architecture, testing, adversarial) that verifies findings against the diff.
 - [RoadmapSmith](https://github.com/PapiScholz/roadmapsmith) - Evidence-backed ROADMAP.md workflows for AI coding agents with validation, sync, and roadmap generation across any tech stack.
 - [Runtype Skills](https://github.com/runtypelabs/skills) - Supercharge your coding agent for AI product development — build, deploy, and operate agents, flows, tools, and surfaces on Runtype's managed edge runtime.
+- [SandBase Codex Plugin](https://github.com/sandbaseai/sandbase-codex-plugin) - Codex plugin with a local MCP bridge and guided skill for discovering, inspecting, and running 2,000+ AI models and APIs.
 - [Sealos](https://github.com/labring/sealos-skills) - Deploy apps to Sealos Cloud from Codex with readiness checks, Dockerfile generation, Compose conversion, image builds, and rollout updates.
 - [Secret Guard](./plugins/mturac/secret-guard) - Pre-commit secret scanner using pattern and entropy detection.
 - [Session Orchestrator](https://github.com/Kanevry/session-orchestrator) - Session orchestration for Claude Code, Codex, and Cursor IDE — structured planning, wave-based execution, VCS integration (GitLab + GitHub), quality gates, and clean session close-out with issue tracking.


### PR DESCRIPTION
## Summary
- add SandBase Codex Plugin to the Community Plugins catalog
- describe its local MCP bridge and guided skill for model/API discovery and execution
- link the canonical plugin repository

The source repository is public, Apache-2.0, includes `.codex-plugin/plugin.json`, `SECURITY.md`, a lockfile, and a passing HOL Plugin Scanner workflow:
https://github.com/sandbaseai/sandbase-codex-plugin/actions/runs/33065674359
