### PR TITLE
Add Rootly MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Reviewable HTML Workbench](https://github.com/u-ichi/reviewable-html-workbench) - Generate reviewable HTML documents, serve previews, collect inline review comments, and feed review outcomes back into agent workflows.
 - [River Review](https://github.com/s977043/river-review) - Versioned Skill Registry of code-review skills driven by a perspective-based review agent (code, security, performance, architecture, testing, adversarial) that verifies findings against the diff.
 - [RoadmapSmith](https://github.com/PapiScholz/roadmapsmith) - Evidence-backed ROADMAP.md workflows for AI coding agents with validation, sync, and roadmap generation across any tech stack.
+- [Rootly MCP Server](https://github.com/rootlyhq/rootly-mcp-server) - Manage and resolve production incidents from MCP-compatible AI assistants through dynamically generated, access-controlled Rootly API tools.
 - [Runtype Skills](https://github.com/runtypelabs/skills) - Supercharge your coding agent for AI product development — build, deploy, and operate agents, flows, tools, and surfaces on Runtype's managed edge runtime.
 - [Sealos](https://github.com/labring/sealos-skills) - Deploy apps to Sealos Cloud from Codex with readiness checks, Dockerfile generation, Compose conversion, image builds, and rollout updates.
 - [Secret Guard](./plugins/mturac/secret-guard) - Pre-commit secret scanner using pattern and entropy detection.


### PR DESCRIPTION
## Summary

- Add [Rootly MCP Server](https://github.com/rootlyhq/rootly-mcp-server) to the **Tools & Integrations** catalog section.
- Describe its incident-management capabilities and access-controlled, dynamically generated Rootly API tools.

## Verification

- Confirmed the source repository is public and active at release v2.0.6.
- Built the package from the latest `master` and verified it fetched and parsed the Rootly OpenAPI schema, constructed the filtered FastMCP server, and exposed the CLI successfully.
- Ran `scripts/validate-contribution.py --base-ref origin/main`; the new Rootly entry passed catalog validation.