### PR TITLE
Add ZCode section: zcode-ru — Russian locale pack for the ZCode desktop app

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,14 @@ submitting a repository.
 
 - [dsh-deja](https://github.com/vshulcz/deja-vu) - Brings the session history of nineteen other coding agents into DeepSeek Harness: recall, session digest and per-file history tools over a local index, plus optional automatic recall.
 
+### ZCode Plugins & Localization
+
+ZCode (Z.ai) ships its desktop UI with en-US/zh-CN dictionaries compiled into
+`app.asar`; community packs add further locales on top of an installed app.
+Add verified community localization packs and plugins here in alphabetical order.
+
+- **[zcode-ru](https://github.com/warment/zcode-ru)** — Russian (ru-RU) localization pack for the ZCode desktop app (3.10.1): 5,018 UI strings (100% of the renderer corpus), third language in the selector with English fallback, one-command installer with backup/restore. MIT.
+
 ## Formats & Development
 
 AI extensions use several overlapping formats. Agent Skills provide reusable instructions, MCP servers expose tools and data, DeepSeek Harness loads Cordis modules/npm packages, and client-specific plugin manifests package those capabilities for installation. Grok Build and Kimi Code each have native plugin manifests and runtime installers. Prefer open formats where practical, then add client adapters for the assistants you support.


### PR DESCRIPTION
## What

Adds a **ZCode Plugins & Localization** section (after DeepSeek Harness Plugins, mirroring the per-harness structure) with one verified entry:

- [zcode-ru](https://github.com/warment/zcode-ru) — Russian (ru-RU) localization pack for the ZCode desktop app (Z.ai, 3.10.1): 5,018 UI strings — 100% of the renderer corpus, third language in the selector (System / English / Русский), English fallback for new upstream strings, one-command installer with automatic backup/restore. MIT.

## Why

ZCode (Z.ai's agentic desktop app) has a growing community ecosystem (account switchers, ACP adapters, a JetBrains plugin, remote clients) but no section here yet. Localization packs are a natural first entry — the vendor's feedback tracker consolidates locale requests in zai-org/feedback#151 and cites this pack as evidence of demand (announcement: zai-org/feedback#425).

## Notes

- Follows the existing per-harness section format (intro on the localization mechanism + alphabetical entries)
- Official plugin marketplace for reference: zai-org/zcode-plugins (localization-track proposal: zai-org/zcode-plugins#3)