### PR TITLE
Add 'mcp-local-memory' project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Maestro](https://github.com/mbanderas/maestro) - Opt-in local multi-CLI fusion engine and orchestration doctrine that fans a prompt across model CLIs, then judges and synthesizes one grounded answer.
 - [MailAgent](https://github.com/Alex0nder/MailAgent) - Temporary inboxes for Codex — OTP, magic links, signup QA, simulate-first autotests (23 MCP tools).
 - [MCP Migration Check](https://github.com/AlpayC/mcp-migration-check) - Deterministic MCP 2026-07-28 migration checker with an agent skill, CLI, GitHub Action, and hosted web probe powered by one rule engine.
+- [mcp-local-memory](https://github.com/Beledarian/mcp-local-memory) - A lightweight, powerful local memory server for AI agents supporting text, entities, relations, and time-based recall.
 - [MegaLinter](https://github.com/oxsecurity/megalinter) - Set up, run and fix MegaLinter on any repository, covering 100+ linters and formatters for 69+ languages and 23+ formats, in CI or locally, with per-linter fix guides for the agent.
 - [MeMesh](https://github.com/PCIRCLE-AI/memesh) - Local SQLite memory shared by Claude Code, Codex, Gemini, Cursor, and other MCP clients, captured automatically by hooks from real work and injected at the moment the agent acts.
 - [memi](https://github.com/sarveshsea/memi) - Interface understanding and design-system memory for Codex, Claude Code, Cursor, and MCP agents with UI audits, Tailwind token extraction, shadcn registry workflows, and a bundled Codex plugin.


### PR DESCRIPTION
Added a new project entry for 'mcp-local-memory' in the README. - as requested in https://github.com/Beledarian/mcp-local-memory/issues/10