### PR TITLE
fix(catalog): restore plugin section placement

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
   "source": "awesome-ai-plugins",
-  "last_updated": "2026-08-29",
+  "last_updated": "2026-08-30",
   "plugins": [
     {
       "name": "Registry Broker",
@@ -3200,6 +3200,21 @@
       "install_url": "https://raw.githubusercontent.com/labyrinth-analytics/loredocs/HEAD/.codex-plugin/plugin.json"
     },
     {
+      "name": "MCP Migration Check",
+      "displayName": "MCP Migration Check",
+      "description": "Deterministic MCP 2026-07-28 migration checker with an agent skill, CLI, GitHub Action, and hosted web probe powered by one rule engine",
+      "category": "Development & Workflow",
+      "source": "awesome-ai-plugins",
+      "platform": "codex",
+      "ecosystems": [
+        "codex"
+      ],
+      "owner": "AlpayC",
+      "repo": "mcp-migration-check",
+      "url": "https://github.com/AlpayC/mcp-migration-check",
+      "install_url": "https://raw.githubusercontent.com/AlpayC/mcp-migration-check/HEAD/.codex-plugin/plugin.json"
+    },
+    {
       "name": "MegaLinter",
       "displayName": "MegaLinter",
       "description": "Set up, run and fix MegaLinter on any repository, covering 100+ linters and formatters for 69+ languages and 23+ formats, in CI or locally, with per-linter fix guides for the agent",
@@ -3634,6 +3649,34 @@
       "repo": "deja-vu",
       "url": "https://github.com/vshulcz/deja-vu",
       "install_url": "https://raw.githubusercontent.com/vshulcz/deja-vu/HEAD/kimi.plugin.json"
+    },
+    {
+      "name": "dsh-config-manager",
+      "displayName": "dsh-config-manager",
+      "description": "Backup, restore, export, import, migrate and sync your complete DeepSeek Harness (DSH) configuration \u2014 settings, model providers, plugins, MCP servers, skills, agent presets and workspaces \u2014 and restore your whole environment on a new machine with one click",
+      "category": "DeepSeek Harness Plugins",
+      "source": "awesome-ai-plugins",
+      "platform": "deepseek-harness",
+      "ecosystems": [
+        "deepseek-harness"
+      ],
+      "owner": "xiajiajun516",
+      "repo": "dsh-config-manager",
+      "url": "https://github.com/xiajiajun516/dsh-config-manager"
+    },
+    {
+      "name": "Engramory",
+      "displayName": "Engramory",
+      "description": "Curated, file-based long-term memory for DSH agents \u2014 plain markdown notes in one store shared across hosts, with the index size cap enforced as a monotonic `ctx.tools.guard()` refusal rather than a reminder. Install: `dsh plugin --profile <name> add dsh-engramory`",
+      "category": "DeepSeek Harness Plugins",
+      "source": "awesome-ai-plugins",
+      "platform": "deepseek-harness",
+      "ecosystems": [
+        "deepseek-harness"
+      ],
+      "owner": "tinqiao-oss",
+      "repo": "engramory",
+      "url": "https://github.com/tinqiao-oss/engramory"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -33,9 +33,6 @@
 
 ## Contents
 
-- [dsh-config-manager](https://github.com/xiajiajun516/dsh-config-manager) - Backup, restore, export, import, migrate and sync your complete DeepSeek Harness (DSH) configuration — settings, model providers, plugins, MCP servers, skills, agent presets and workspaces — and restore your whole environment on a new machine with one click.
-- [Engramory](https://github.com/tinqiao-oss/engramory) - Curated, file-based long-term memory for DSH agents — plain markdown notes in one store shared across hosts, with the index size cap enforced as a monotonic `ctx.tools.guard()` refusal rather than a reminder. Install: `dsh plugin --profile <name> add dsh-engramory`.
-- [MCP Migration Check](https://github.com/AlpayC/mcp-migration-check) - Deterministic MCP 2026-07-28 migration checker with an agent skill, CLI, GitHub Action, and hosted web probe powered by one rule engine.
 - [Start Here](#start-here)
 - [Official Plugins](#official-plugins)
 - [Community Plugins](#community-plugins)
@@ -198,6 +195,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [LVTD Skills](https://github.com/LVTD-LLC/skills) - Reusable Agent Skills for Codex, Claude Code, and compatible clients, covering Django, Rust, Cookiecutter, SEO, traction, product marketing, and nonfiction publishing workflows.
 - [Maestro](https://github.com/mbanderas/maestro) - Opt-in local multi-CLI fusion engine and orchestration doctrine that fans a prompt across model CLIs, then judges and synthesizes one grounded answer.
 - [MailAgent](https://github.com/Alex0nder/MailAgent) - Temporary inboxes for Codex — OTP, magic links, signup QA, simulate-first autotests (23 MCP tools).
+- [MCP Migration Check](https://github.com/AlpayC/mcp-migration-check) - Deterministic MCP 2026-07-28 migration checker with an agent skill, CLI, GitHub Action, and hosted web probe powered by one rule engine.
 - [MegaLinter](https://github.com/oxsecurity/megalinter) - Set up, run and fix MegaLinter on any repository, covering 100+ linters and formatters for 69+ languages and 23+ formats, in CI or locally, with per-linter fix guides for the agent.
 - [MeMesh](https://github.com/PCIRCLE-AI/memesh) - Local SQLite memory shared by Claude Code, Codex, Gemini, Cursor, and other MCP clients, captured automatically by hooks from real work and injected at the moment the agent acts.
 - [memi](https://github.com/sarveshsea/memi) - Interface understanding and design-system memory for Codex, Claude Code, Cursor, and MCP agents with UI audits, Tailwind token extraction, shadcn registry workflows, and a bundled Codex plugin.
@@ -394,7 +392,9 @@ plugin tutorial](https://github.com/deepseek-ai/deepseek-harness/blob/master/doc
 and the [`dsh-plugin` community topic](https://github.com/topics/dsh-plugin) before
 submitting a repository.
 
+- [dsh-config-manager](https://github.com/xiajiajun516/dsh-config-manager) - Backup, restore, export, import, migrate and sync your complete DeepSeek Harness (DSH) configuration — settings, model providers, plugins, MCP servers, skills, agent presets and workspaces — and restore your whole environment on a new machine with one click.
 - [dsh-deja](https://github.com/vshulcz/deja-vu) - Brings the session history of nineteen other coding agents into DeepSeek Harness: recall, session digest and per-file history tools over a local index, plus optional automatic recall.
+- [Engramory](https://github.com/tinqiao-oss/engramory) - Curated, file-based long-term memory for DSH agents — plain markdown notes in one store shared across hosts, with the index size cap enforced as a monotonic `ctx.tools.guard()` refusal rather than a reminder. Install: `dsh plugin --profile <name> add dsh-engramory`.
 
 ## Formats & Development
 

--- a/plugins.json
+++ b/plugins.json
@@ -2,12 +2,13 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "name": "awesome-ai-plugins",
   "version": "1.0.0",
-  "last_updated": "2026-08-29",
-  "total": 242,
+  "last_updated": "2026-08-30",
+  "total": 245,
   "platforms": [
     "codex",
     "grok",
-    "kimi"
+    "kimi",
+    "deepseek-harness"
   ],
   "plugins": [
     {
@@ -2994,6 +2995,20 @@
       ]
     },
     {
+      "name": "MCP Migration Check",
+      "url": "https://github.com/AlpayC/mcp-migration-check",
+      "owner": "AlpayC",
+      "repo": "mcp-migration-check",
+      "description": "Deterministic MCP 2026-07-28 migration checker with an agent skill, CLI, GitHub Action, and hosted web probe powered by one rule engine",
+      "category": "Development & Workflow",
+      "platform": "codex",
+      "source": "awesome-ai-plugins",
+      "install_url": "https://raw.githubusercontent.com/AlpayC/mcp-migration-check/HEAD/.codex-plugin/plugin.json",
+      "ecosystems": [
+        "codex"
+      ]
+    },
+    {
       "name": "MegaLinter",
       "url": "https://github.com/oxsecurity/megalinter",
       "owner": "oxsecurity",
@@ -3397,6 +3412,32 @@
       "install_url": "https://raw.githubusercontent.com/vshulcz/deja-vu/HEAD/kimi.plugin.json",
       "ecosystems": [
         "kimi",
+        "deepseek-harness"
+      ]
+    },
+    {
+      "name": "dsh-config-manager",
+      "url": "https://github.com/xiajiajun516/dsh-config-manager",
+      "owner": "xiajiajun516",
+      "repo": "dsh-config-manager",
+      "description": "Backup, restore, export, import, migrate and sync your complete DeepSeek Harness (DSH) configuration \u2014 settings, model providers, plugins, MCP servers, skills, agent presets and workspaces \u2014 and restore your whole environment on a new machine with one click",
+      "category": "DeepSeek Harness Plugins",
+      "platform": "deepseek-harness",
+      "source": "awesome-ai-plugins",
+      "ecosystems": [
+        "deepseek-harness"
+      ]
+    },
+    {
+      "name": "Engramory",
+      "url": "https://github.com/tinqiao-oss/engramory",
+      "owner": "tinqiao-oss",
+      "repo": "engramory",
+      "description": "Curated, file-based long-term memory for DSH agents \u2014 plain markdown notes in one store shared across hosts, with the index size cap enforced as a monotonic `ctx.tools.guard()` refusal rather than a reminder. Install: `dsh plugin --profile <name> add dsh-engramory`",
+      "category": "DeepSeek Harness Plugins",
+      "platform": "deepseek-harness",
+      "source": "awesome-ai-plugins",
+      "ecosystems": [
         "deepseek-harness"
       ]
     }

--- a/scripts/validate-contribution.py
+++ b/scripts/validate-contribution.py
@@ -171,16 +171,31 @@ def current_readme_section(readme_lines: list[str], line_number: int) -> str:
     return heading
 
 
+def readme_urls_in_section(readme: str, section: str) -> set[str]:
+    """Return normalized repository URLs listed beneath one level-two heading."""
+
+    current_section = ""
+    urls: set[str] = set()
+    for line in readme.splitlines():
+        heading = re.match(r"^##\s+(.+?)\s*$", line)
+        if heading:
+            current_section = heading.group(1).strip()
+            continue
+        if current_section != section:
+            continue
+        match = README_ENTRY_RE.match(line.strip())
+        if match:
+            urls.add(normalize_url(match.group(2)))
+    return urls
+
+
 def get_new_readme_entries_from_diff(diff: str, base_readme: str, head_readme: str) -> list[Contribution]:
     """Find newly added Community Plugins entries in a README diff."""
 
     if not diff:
         return []
 
-    base_urls = {
-        normalize_url(match.group(2))
-        for match in README_ENTRY_RE.finditer(base_readme)
-    }
+    base_urls = readme_urls_in_section(base_readme, "Community Plugins")
     readme_lines = head_readme.splitlines()
 
     entries: list[Contribution] = []

--- a/tests/test-validate-contribution.py
+++ b/tests/test-validate-contribution.py
@@ -111,6 +111,32 @@ class ValidateContributionTests(unittest.TestCase):
         malformed = MODULE.malformed_community_plugin_lines(diff, head)
         self.assertEqual(len(malformed), 1)
 
+    def test_relocated_entry_is_detected_when_base_url_only_exists_in_contents(self) -> None:
+        base = (
+            "## Contents\n"
+            "- [Moved Plugin](https://github.com/example/moved-plugin) - moved later\n"
+            "## Community Plugins\n"
+            "- [Existing Plugin](https://github.com/example/existing-plugin) - already cataloged\n"
+        )
+        head = (
+            "## Contents\n"
+            "## Community Plugins\n"
+            "- [Moved Plugin](https://github.com/example/moved-plugin) - moved later\n"
+            "- [Existing Plugin](https://github.com/example/existing-plugin) - already cataloged\n"
+        )
+        diff = (
+            "@@ -1,4 +1,4 @@\n"
+            " ## Contents\n"
+            "- [Moved Plugin](https://github.com/example/moved-plugin) - moved later\n"
+            " ## Community Plugins\n"
+            "+- [Moved Plugin](https://github.com/example/moved-plugin) - moved later\n"
+            " - [Existing Plugin](https://github.com/example/existing-plugin) - already cataloged\n"
+        )
+
+        entries = MODULE.get_new_readme_entries_from_diff(diff, base, head)
+
+        self.assertEqual([entry.repo for entry in entries], ["moved-plugin"])
+
 
 class PublishOpenPrChecksTests(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
## Summary

- Keep the table of contents limited to navigation links.
- Place the DeepSeek Harness and Development & Workflow entries in their intended catalog sections.
- Synchronize generated catalog artifacts with the corrected listings.

## Testing

- `python3 scripts/check-alphabetical.py README.md`
- `PYTHONDONTWRITEBYTECODE=1 python3 scripts/validate-contribution.py --base-ref origin/main`
- `PYTHONDONTWRITEBYTECODE=1 python3 tests/test-generate-plugins-json.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 tests/test-sync-scanner-action.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 tests/test-validate-contribution.py`
- `python3 -m json.tool plugins.json`
- `python3 -m json.tool .agents/plugins/marketplace.json`

## Notes

- Source-repository scanner findings are advisory; the contribution gate remains passing. Engramory's scanner result is below the configured advisory threshold and does not block listing.
