### PR TITLE
Add Zero Slop to Development & Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [X (Twitter) Skills](https://github.com/sergebulaev/x-skills) - Codex-ready X (Twitter) marketing bundle with a native .codex-plugin manifest: tweet and thread writing with corpus-validated hook formulas (validated against ~450 top tweets), AI-tell humanizer, hook extraction, reply drafting, content planning, and audience insights; also works in Claude Code.
 - [X Twitter Scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data, monitored workflows, HMAC webhooks, and MCP access through the Xquik REST API with confirmation-gated write guidance.
 - [Yandex Direct](https://github.com/nebelov/yandex-direct-for-all) - GitHub-ready Codex plugin bundle for Yandex Direct, Wordstat, Metrika, and Roistat.
+- [Zero Slop](https://github.com/manavmishra/ZeroSlop) - Say no to AI slop: a human-in-the-loop learning agentic workflow skill that scores text 0-100 for AI slop and rewrites it tastefully, with a standard-library Python scorer that has zero dependencies and runs offline.
 - [Zotero Research Tools](https://github.com/summer521521/Zotero_Research_plugin) - Connects Codex to Zotero Desktop for local-library search, citation export, collection and tag inspection, and research workflow support.
 
 ### Grok Plugins


### PR DESCRIPTION
Submitting [Zero Slop](https://github.com/manavmishra/ZeroSlop) at your invitation in [manavmishra/ZeroSlop#2](https://github.com/manavmishra/ZeroSlop/issues/2). Thanks for reaching out.

One entry, in the format `CONTRIBUTING.md` specifies, placed alphabetically at the end of **Community Plugins → Development & Workflow**:

```markdown
- [Zero Slop](https://github.com/manavmishra/ZeroSlop) - Scores prose 0-100 for AI slop and rewrites it under a local fact gate that rejects any version changing a name, number, quotation, or link; the scorer is standard-library Python with zero dependencies and runs offline.
```

Against your checklist:

- **Search first** — not currently listed; I grepped the README for both spellings.
- **Verify it works** — 2.7.7 is on npm and installs with `npx zero-slop install` or `npx skills add manavmishra/ZeroSlop --global`. 252 tests run on every push.
- **Follow the format** — one sentence, `- [Name](url) - Description.`
- **Appropriate section** — it ships `.codex-plugin/plugin.json`, so it is a Codex-compatible plugin. Development & Workflow fits it better than Tools & Integrations, since it is a skill rather than an MCP server. Move it if you disagree.

What it does that the other editors here do not: the fact gate is a program rather than an instruction. Any rewrite that adds or drops a name, number, quotation, link, code block or table is rejected and redone, so the model is never trusted to have preserved the facts. It is deliberately not an authorship detector — the score describes the writing and the docs repeat that it says nothing about who wrote a text.

It also runs in Claude Code, Cursor, Zed, Warp and OpenCode from the same SKILL.md, with a chat-only route for ChatGPT and Claude.ai.

I could not run `pipx run plugin-scanner` locally as pipx is not installed here. Happy to run it and report back if that is a blocker.

MIT. Benchmark with the drafts, mappings and hashes committed: https://zero-slop.ai/benchmark/