### PR TITLE
Add FlexViz to Community Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Espresso](https://github.com/mirkobozzetto/espresso) - Full token-saving stack in one plugin - output compression, global rules, RTK hook, Caveman ultra, GitNexus config. Detects existing setup, installs only what's missing. Works on Claude Code and Codex.
 - [falsegreen-skill](https://github.com/vinicq/falsegreen-skill) - Finds tests that stay green when the code they cover is broken, applying six ordered judgments over Python, TypeScript, JavaScript, and Robot Framework suites in Codex CLI and Claude Code.
 - [Flaky Detector](./plugins/mturac/flaky-detector) - Run a test command N times, report per-test flakiness %.
+- [FlexViz](https://github.com/flex-analytics/flexviz) - Interactive cross-filter dashboards for large datasets with a Claude Code skill for agent-driven data exploration.
 - [Frappe Agent](https://github.com/Dkm0315/frappe-agent) - Frappe and ERPNext coding, customization, bench, and review intelligence for Codex.
 - [GCF Proxy](https://github.com/blackwell-systems/gcf-codex-plugin) - Save 71% on MCP tool call tokens by wrapping any server with GCF encoding, with session stats hook and setup skill.
 - [Generative Media Skills](https://github.com/SamurAIGPT/Generative-Media-Skills) - 13 skills for image, video, and audio generation using 100+ models - FLUX, Midjourney v7, Veo3, Kling 3.0, Suno, and HunyuanVideo via muapi.ai.


### PR DESCRIPTION
## Summary

Adds [FlexViz](https://github.com/flex-analytics/flexviz) to the Community Plugins section.

FlexViz is a Polars-native Python library for interactive cross-filter dashboards on large datasets. It ships a packaged Claude Code skill (`flexviz-explore`) that lets the agent serve a local Parquet/CSV file as a live dashboard the user explores in their browser.

- **Repository:** https://github.com/flex-analytics/flexviz
- **Category:** Community Plugins (alphabetical, between Frappe Agent and GCF Proxy)
- **Verified:** skill installs and runs via `claude skill install`