### PR TITLE
Add TermaGITchi to Tools & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Team Skills Platform](https://github.com/Colin4k1024/tsp) - Role-based team delivery framework — Tech Lead-orchestrated 8-role system with 195+ skills, 27 specialist agents, 80+ commands, hooks, and ECC harness for Claude Code, Codex, and OpenCode.
 - [Test Gap](./plugins/mturac/test-gap) - Find lines in your diff lacking test coverage (Cobertura, lcov, coverage.json).
 - [TODO Harvest](./plugins/mturac/todo-harvest) - TODO/FIXME/HACK scan with `git blame` author + age.
+- [TermaGITchi](https://github.com/TevvvB/termagitchi) - Stable per-worktree identity for parallel Claude Code, Codex, and tmux sessions; mood reads repository hygiene, not what the agent is doing.
 - [token-optimizer](https://github.com/ooples/token-optimizer-mcp) - Spend less context and keep the conclusions across 16 coding clients including Claude Code, Codex, Gemini CLI, Cursor, and Copilot — diff-only re-reads, paths-only search, out-of-context stashing, and a local ledger that measures each tool's actual return.
 - [Tool Advisor](https://github.com/dragon1086/claude-skills) - Read-only meta-skill that scans your MCP servers, skills, plugins, and CLI tools, then suggests up to three ranked approaches (Methodical / Fast / Deep) with a copy-paste Quick Action table.
 - [trace-mcp](https://github.com/nikolai-vysotskyi/trace-mcp) - Precomputed code-intelligence graph served over MCP — symbol search, call graphs, change impact, and test mapping as structured answers instead of whole-file reads.


### PR DESCRIPTION
Adds [TermaGITchi](https://github.com/TevvvB/termagitchi) under Tools & Integrations, alphabetically after Telnyx.

It's a status-line creature per agent session: identity is a hash of the session, mood comes from the worktree (uncommitted files, unpushed commits, tests). Claude Code is wired end to end; Codex hooks work once trusted; tmux/shell work with anything. MIT, single static Go binary.

Scanner CI is optional for listing per CONTRIBUTING.md; I have not added the HOL scanner action.

Verified locally: `pets install` against Claude Code, and Codex 0.149.0 once hooks are trusted.