### PR TITLE
Add AgentCall to Tools & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 
 - [Agent Message Queue](https://github.com/avivsinai/agent-message-queue) - File-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations.
 - [Agent Vision](https://github.com/zfifteen/agent-vision) - macOS-only local camera plugin for explicit snapshots, streaming controls, and file-backed image input.
+- [AgentCall](https://github.com/pattern-ai-labs/agentcall) - Lets Claude Code, Codex, Cursor, Gemini CLI, and 30+ other agents join Google Meet, Zoom, or Microsoft Teams as a speaking, listening, presenting participant with text-to-speech, live transcripts, screenshare, and an avatar camera feed.
 - [Agentgram](https://github.com/jerryfane/agentgram) - Send explicit Telegram messages from Codex and local AI agents through a Telegram bot token and chat id.
 - [AgentGuards](https://github.com/alelaguard/agentguards-plugins) - LLM security guardrails for Codex with enforcing hooks and MCP tools: jailbreak and prompt-injection detection, web-content scanning, data-exfiltration blocking, and destructive-command authorization.
 - [agentmailkit](https://github.com/ariaxhan/agentmailkit) - MCP server for scheduled LLM-written email digests from RSS, web and local sources: tools list_jobs/run_job/preview_job/list_plugins, local-first, run_job dry-run by default; `pip install "agentmailkit[mcp]"` then `agentmailkit mcp`.


### PR DESCRIPTION
## Summary

Adds [AgentCall](https://github.com/pattern-ai-labs/agentcall) to the **Tools & Integrations** section of Community Plugins, at the list maintainers' request in pattern-ai-labs/agentcall#10.

AgentCall gives an existing coding agent a seat in a video meeting. It joins as a real participant - speaks via text-to-speech, receives live transcripts, screenshots shared screens, screenshares URLs, posts in meeting chat, and renders an animated avatar as its camera feed - while keeping full session context, so it can read code, edit files and run commands mid-call.

Repository: https://github.com/pattern-ai-labs/agentcall
License: MIT. Ships `gemini-extension.json` (Gemini CLI extension), `.claude-plugin/plugin.json` + `marketplace.json` (Claude Code plugin), and a portable `SKILL.md` (Codex, Cursor, OpenCode, Windsurf and 30+ others).

Note for the reviewer:
The issue suggested describing it as a Gemini CLI extension. I widened the wording so the entry covers all three install formats, and placed it under Tools & Integrations rather than Development & Workflow since it adds an I/O channel to external platforms rather than changing how the agent writes code - alongside existing entries like Cadence Code (voice), Call-E (phone), Agentgram (Telegram) and Agent Vision (camera).

## Verification

- Installed the skill in Claude Code and used it to join a live Google Meet call, with voice output and live transcripts working
- `python scripts/check-alphabetical.py README.md` - `OK: 'Tools & Integrations' (105 items)`
- Entry matches the catalog format regex in `scripts/validate-contribution.py`
- Repository is public, not archived, MIT-licensed, with recent commits

## Checklist

- [x] Searched the catalog - not already listed
- [x] Alphabetical order, between `Agent Vision` and `Agentgram`
- [x] One-sentence description
- [x] Single-line diff, no other files touched