### PR TITLE
Add immich-photo-manager to Tools & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [GH Project](https://github.com/zfifteen/gh-project-plugin) - Create GitHub repositories from Codex with inferred defaults, native menus, explicit confirmation, and deterministic local cloning.
 - [Hermes Tweet](https://github.com/Xquik-dev/hermes-tweet) - Hermes Agent X/Twitter plugin for read-first social research, monitoring, and approval-gated actions through Xquik.
 - [Hostinger API MCP](https://github.com/hostinger/api-mcp-server) - Manage Hostinger VPS, domains, DNS, hosting, and billing through MCP tools backed by the official Hostinger API.
+- [immich-photo-manager](https://github.com/drolosoft/immich-photo-manager) - MCP server and Claude Code plugin for self-hosted Immich photo libraries: CLIP and OCR search, geographic album curation, duplicate detection, people and faces, metadata repair, video frames and PDF photobooks, 94 tools and 13 skills tested live on Immich 2.x and 3.x, also via uvx or Docker.
 - [Jenkins CLI](https://github.com/avivsinai/jenkins-cli) - GitHub CLI-style interface for Jenkins controllers with jobs, pipelines, runs, logs, artifacts, credentials, and nodes.
 - [Kachilu Browser](https://github.com/kachilu-inc/kachilu-browser) - Anti-bot-aware browser automation for AI agents with MCP tools, CAPTCHA-aware workflows, and WSL2 Windows browser support.
 - [KiCad Happy](https://github.com/aklofas/kicad-happy) - KiCad EDA skills for schematic analysis, PCB layout review, component sourcing, BOM management, and manufacturing preparation.


### PR DESCRIPTION
Adds immich-photo-manager to Community Plugins, Tools & Integrations.

It was listed here before (PR #13, April) and the entry went away in the May restructure of the README, so this is the same project back with the current description. It is an MCP server and Claude Code plugin for self-hosted Immich photo libraries: you ask in plain words ("show me the photos from Italy", "find the picture with the train ticket", "create albums for everywhere I have traveled", "find duplicates", "make me a PDF of this trip") and it does the API work. 94 tools, 13 skills, 5 slash commands.

Every release runs live against real Immich 2.7.5 and 3.1.0 in Docker before it is tagged, all tools over MCP, and the kit for that is in `tests/live/`. It also speaks both MCP protocol eras (legacy handshake and the stateless 2026-07-28 revision). Install as a plugin from the clone, with `uvx immich-photo-manager`, or as a Docker image (`ghcr.io/drolosoft/immich-photo-manager`).

Plugin scanner: 100/100 in April, and the repo has a `.plugin-scanner.toml`. MIT, Python 3.10+, active (2.0.10 tagged this week).
