### PR TITLE
Add Scholar Feed to Tools & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Remotion Plugin](https://github.com/tim-osterhus/codex-remotion-plugin) - Build parameterized Remotion videos in Codex with the official Remotion docs MCP, composition scaffolding, and a data-driven launch-video workflow.
 - [ru-text](https://github.com/talkstream/ru-text) - Russian text quality — ~1,044 rules for typography, info-style, editorial, UX writing, and business correspondence.
 - [Rust Reverse Engineering](https://github.com/jingjing2222/rust-reverse-engineering-skill) - Reverse engineer Rust binaries and libraries: triage targets, demangle symbols, recover crate namespaces, and map panic, unwind, async, and FFI paths.
+- [Scholar Feed](https://github.com/YGao2005/scholar-feed-mcp) - MCP server over 600k+ CS/AI/ML papers: rank by citations or forecast rising impact, trace 23.2M citation edges, and pull full text and BibTeX; `npx -y scholar-feed-mcp`.
 - [ScrapeGraph AI](https://github.com/ScrapeGraphAI/just-scrape) - AI-powered web scraping CLI to search, scrape, extract structured JSON, crawl, and monitor web pages via the ScrapeGraph AI API.
 - [SEO Dungeon](https://github.com/avalonreset/seo-dungeon) - Gamified local SEO audits that turn website issues into 16-bit dungeon battles for Codex, Claude, and Gemini CLI workflows.
 - [Shots](https://github.com/hitSlop/shots) - Agent-native App Store screenshot, app icon, ASO, and localization workflows through the hosted Shots MCP server.


### PR DESCRIPTION
Adds Scholar Feed to **Tools & Integrations**, as invited by the maintainer in YGao2005/scholar-feed-mcp#56.

```
- [Scholar Feed](https://github.com/YGao2005/scholar-feed-mcp) - MCP server over 600k+ CS/AI/ML papers: rank by citations or forecast rising impact, trace 23.2M citation edges, and pull full text and BibTeX; `npx -y scholar-feed-mcp`.
```

One line, inserted between `Rust Reverse Engineering` and `ScrapeGraph AI` to keep the section sorted. MIT, 26 tools, TypeScript, works anonymously or with a free key.

### Validation

Both PR-gate scripts were run locally against `upstream/main`:

- `scripts/validate-contribution.py` — **passes**: `All 1 contribution entry passed catalog validation.` It flags `scanner CI not_detected; queued for advisory centralized scan`, which I understand is the documented 10% trust-score reduction rather than a blocker. Happy to add the scanner workflow in a follow-up if you'd prefer it before listing.
- `scripts/check-alphabetical.py` — reports `OK: 'Tools & Integrations' (108 items)`, so this entry is correctly placed.

### Heads-up on the alphabetical check

That script currently exits non-zero on **`Development & Workflow`**, and it does so on unmodified `upstream/main` too — I confirmed by stashing this change and re-running: the same section fails, and `Tools & Integrations` reports `OK` at both 107 and 108 items. So the red check is pre-existing and unrelated to this PR.

The out-of-order pairs there look like `commit narrator` / `codex-profiles`, `delx recovery` / `dely` / `deps doctor`, `env lint` / `encore lite`, `flaky detector` / `finbridge`, and `termagitchi` / `test gap`. I deliberately left them alone rather than bundle a ~200-entry re-sort into a one-line addition — glad to send that as a separate PR if it's useful.

I also did not touch `plugins.json` or `.agents/plugins/marketplace.json`, since those appear to be generated (`scripts/generate_plugins_json.py`, and the sync commit on `main`).
