### PR TITLE
Add kunglao-agent to Tools & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,10 +378,10 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Kachilu Browser](https://github.com/kachilu-inc/kachilu-browser) - Anti-bot-aware browser automation for AI agents with MCP tools, CAPTCHA-aware workflows, and WSL2 Windows browser support.
 - [KiCad Happy](https://github.com/aklofas/kicad-happy) - KiCad EDA skills for schematic analysis, PCB layout review, component sourcing, BOM management, and manufacturing preparation.
 - [Kindle Highlights](https://github.com/l3a0/claude-plugins) - Claude Code skill that exports a book's Kindle highlights to verbatim, location-cited Markdown, recovering the ones Amazon's export limit truncates or hides (macOS).
-- [kunglao-agent](https://github.com/amd2g2zz/kunglao-agent) - Reverse-engineering expert agent for binaries, firmware, protocols, and web/JS: MCP servers registered by kunglao-init (ghidra, sequential-thinking, x64dbg, ...), see the MCP supply table under Internals.
 - [Kreuzberg](https://github.com/kreuzberg-dev/plugins) - Local document extraction for 91+ formats with skills for CLI usage, OCR, table extraction, output formats, and a local MCP server.
 - [Kreuzberg Cloud](https://github.com/kreuzberg-dev/plugins) - Managed document extraction for Codex with API-key setup, presigned uploads, job tracking, webhook workflows, and usage guidance.
 - [Kreuzcrawl](https://github.com/kreuzberg-dev/plugins) - Web crawling and scraping for Codex with skills for single-page scraping, site crawls, URL mapping, and headless browser fallback.
+- [kunglao-agent](https://github.com/amd2g2zz/kunglao-agent) - Reverse-engineering expert agent for binaries, firmware, protocols, and web/JS: MCP servers registered by kunglao-init (ghidra, sequential-thinking, x64dbg, ...), see the MCP supply table under Internals.
 - [Lacuna Music](https://github.com/JOYLINK-LTD/lacuna-plugin) - Generate original instrumental music and vocal songs from Codex through the Lacuna MCP server.
 - [Langfuse Observability](https://github.com/avivsinai/langfuse-mcp) - Query traces, debug exceptions, analyze sessions, and manage prompts via MCP tools.
 - [Launch Fast](https://github.com/BlockchainHB/launchfast_codex_plugin) - Official Launch Fast plugin adapter for rapid SaaS deployment.

--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Kachilu Browser](https://github.com/kachilu-inc/kachilu-browser) - Anti-bot-aware browser automation for AI agents with MCP tools, CAPTCHA-aware workflows, and WSL2 Windows browser support.
 - [KiCad Happy](https://github.com/aklofas/kicad-happy) - KiCad EDA skills for schematic analysis, PCB layout review, component sourcing, BOM management, and manufacturing preparation.
 - [Kindle Highlights](https://github.com/l3a0/claude-plugins) - Claude Code skill that exports a book's Kindle highlights to verbatim, location-cited Markdown, recovering the ones Amazon's export limit truncates or hides (macOS).
+- [kunglao-agent](https://github.com/amd2g2zz/kunglao-agent) - Reverse-engineering expert agent for binaries, firmware, protocols, and web/JS: MCP servers registered by kunglao-init (ghidra, sequential-thinking, x64dbg, ...), see the MCP supply table under Internals.
 - [Kreuzberg](https://github.com/kreuzberg-dev/plugins) - Local document extraction for 91+ formats with skills for CLI usage, OCR, table extraction, output formats, and a local MCP server.
 - [Kreuzberg Cloud](https://github.com/kreuzberg-dev/plugins) - Managed document extraction for Codex with API-key setup, presigned uploads, job tracking, webhook workflows, and usage guidance.
 - [Kreuzcrawl](https://github.com/kreuzberg-dev/plugins) - Web crawling and scraping for Codex with skills for single-page scraping, site crawls, URL mapping, and headless browser fallback.


### PR DESCRIPTION
Adds **kunglao-agent** to **Tools & Integrations**, as invited by the maintainer in amd2g2zz/kunglao-agent#73.

```
- [kunglao-agent](https://github.com/amd2g2zz/kunglao-agent) - Reverse-engineering expert agent for binaries, firmware, protocols, and web/JS: MCP servers registered by kunglao-init (ghidra, sequential-thinking, x64dbg, ...), see the MCP supply table under Internals.
```

One line, inserted between `Kreuzcrawl` and `Lacuna Music` to keep the section sorted (kr < ku < la). Description is one sentence covering what the project does plus the MCP-supply angle the maintainers highlighted in the invitation.

### Validation

The PR-gate script was run locally against this branch:

- `scripts/validate-contribution.py` — **passes**: `All 1 contribution entry passed catalog validation.` It flags `scanner CI not_detected; queued for advisory centralized scan`, which we understand means the listing can proceed with an advisory centralized scan.
- `scripts/check-alphabetical.py` — the `Tools & Integrations` section passes with our entry in place. The pre-existing out-of-order pairs in other sections (`Development & Workflow`, and legacy ordering pairs inside `Tools & Integrations` like `commit narrator`/`codex-profiles`) were deliberately left alone rather than bundled into a one-line addition.

`plugins.json` and `.agents/plugins/marketplace.json` were not touched, as they appear to be generated (`scripts/generate_plugins_json.py` and the sync commit on `main`).