### PR TITLE
Add Agent Context OS

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -3307,6 +3307,21 @@
       "install_url": "https://raw.githubusercontent.com/2718labs/2718lab-devkit/HEAD/.codex-plugin/plugin.json"
     },
     {
+      "name": "Agent Context OS",
+      "displayName": "Agent Context OS",
+      "description": "Portable Git-backed context and session workflow layer with first-class Claude Code, Codex, and OpenClaw support plus experimental adapters for Hermes, Cursor, and Devin",
+      "category": "Development & Workflow",
+      "source": "awesome-ai-plugins",
+      "platform": "codex",
+      "ecosystems": [
+        "codex"
+      ],
+      "owner": "conorbronsdon",
+      "repo": "agent-context-os",
+      "url": "https://github.com/conorbronsdon/agent-context-os",
+      "install_url": "https://raw.githubusercontent.com/conorbronsdon/agent-context-os/HEAD/.codex-plugin/plugin.json"
+    },
+    {
       "name": "Agent Guild",
       "displayName": "Agent Guild",
       "description": "Vet autonomous agents before delegating work or money, verify portable passports, use escrow, and record signed outcomes across Claude Code, Codex, MCP, A2A, and OpenClaw",

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [A Team](https://github.com/RBraga01/a-team) - Universal multi-agent infrastructure with 25 specialist agents, 16 enforced workflow skills, and a lead orchestrator for Claude Code, Codex CLI, Cursor, and OpenCode.
 - [Aegis](https://github.com/GanyuanRan/Aegis) - An agentic skills framework & software development methodology that works: planning, TDD, debugging, and collaboration workflows.
 - [Agency Continuity Audit](https://github.com/revertcreations/agency-continuity-audit) - Read-only audit that distinguishes durable agent goals, state, corrections, restart evidence, authority boundaries, scheduler claims, and commercial proof from self-reported health.
+- [Agent Context OS](https://github.com/conorbronsdon/agent-context-os) - Portable Git-backed context and session workflow layer with first-class Claude Code, Codex, and OpenClaw support plus experimental adapters for Hermes, Cursor, and Devin.
 - [Agent Deck](https://github.com/not-so-fat/agent-deck) - One MCP for context management: bind self-improving playbooks, MCP tools, and API keys to the session.
 - [Agent Guard](https://github.com/JeongJaeSoon/agent-guard) - Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI.
 - [Agent Guild](https://github.com/AgentTanuki/agent-guild-plugin) - Vet autonomous agents before delegating work or money, verify portable passports, use escrow, and record signed outcomes across Claude Code, Codex, MCP, A2A, and OpenClaw.

--- a/plugins.json
+++ b/plugins.json
@@ -3,7 +3,7 @@
   "name": "awesome-ai-plugins",
   "version": "1.0.0",
   "last_updated": "2026-09-08",
-  "total": 349,
+  "total": 350,
   "platforms": [
     "codex",
     "grok",
@@ -3089,6 +3089,20 @@
       "platform": "codex",
       "source": "awesome-ai-plugins",
       "install_url": "https://raw.githubusercontent.com/2718labs/2718lab-devkit/HEAD/.codex-plugin/plugin.json",
+      "ecosystems": [
+        "codex"
+      ]
+    },
+    {
+      "name": "Agent Context OS",
+      "url": "https://github.com/conorbronsdon/agent-context-os",
+      "owner": "conorbronsdon",
+      "repo": "agent-context-os",
+      "description": "Portable Git-backed context and session workflow layer with first-class Claude Code, Codex, and OpenClaw support plus experimental adapters for Hermes, Cursor, and Devin",
+      "category": "Development & Workflow",
+      "platform": "codex",
+      "source": "awesome-ai-plugins",
+      "install_url": "https://raw.githubusercontent.com/conorbronsdon/agent-context-os/HEAD/.codex-plugin/plugin.json",
       "ecosystems": [
         "codex"
       ]


### PR DESCRIPTION
Adds Agent Context OS to the README and generated marketplace catalogs. The branch includes the upstream catalog merge and reconciled counts; regenerate totals after merging additional listings.

Source fixes are in conorbronsdon/agent-context-os#196: a real Codex workspace-companion manifest, a thin skill routing to the user's selected workspace, pinned validation actions, action update checks, and explicitly synthetic OpenClaw fixtures. Production auth and lifecycle code are unchanged. Four pre-existing date-dependent test fixtures now use a fixed apply-time clock; the expiry-rejection control remains intact.

Local validation passed on source HEAD `b8f40f97fe5ed662021a2563c7b1a6632efed09d`: 722 Python tests (27 skipped), portability suites, hooks, links, component ownership, integration/runtime/bundle/workspace checks, and official Codex plugin validation. Scanner 2.0.1116 passes at 91/100 under the default profile, minimum score 80, and fail-on-high gate. No secret rule, severity, or source-path suppressions.

Authenticated Claude Sonnet 5, free Muse Spark 1.3 Contributor, and free Big Pickle reviewed the source packaging and affected-file clock repair. No verified actionable findings remain. Prior catalog review covered commit `85f72418a7b0b131f6145d4b890ec9ba56af679a`; any subsequent no-content CI-refresh commit preserves that exact tree.
