### PR TITLE
Add Agent QA to Tools & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 ### Tools & Integrations
 
 - [Agent Message Queue](https://github.com/avivsinai/agent-message-queue) - File-based inter-agent messaging with co-op mode, cross-project federation, and orchestrator integrations.
+- [Agent QA](https://github.com/vostride/agent-qa) - Source-available MCP server and Agent Skills for authoring, running, and triaging natural-language web and mobile application tests with reusable execution memory.
 - [Agent Vision](https://github.com/zfifteen/agent-vision) - macOS-only local camera plugin for explicit snapshots, streaming controls, and file-backed image input.
 - [AgentCall](https://github.com/pattern-ai-labs/agentcall) - Lets Claude Code, Codex, Cursor, Gemini CLI, and 30+ other agents join Google Meet, Zoom, or Microsoft Teams as a speaking, listening, presenting participant with text-to-speech, live transcripts, screenshare, and an avatar camera feed.
 - [Agentgram](https://github.com/jerryfane/agentgram) - Send explicit Telegram messages from Codex and local AI agents through a Telegram bot token and chat id.


### PR DESCRIPTION
Adds Agent QA under **Community Plugins → Tools & Integrations**. Its MCP server and Agent Skills expose natural-language web and mobile application test authoring, execution, and triage, with reusable execution memory.

Validation:

- The new entry is alphabetical within Tools & Integrations. The whole-file alphabetical check currently fails on the upstream Development & Workflow section. Moving its seven misplaced relative-link entries also makes the contribution validator reject them as malformed additions, so this PR leaves those existing entries intact and records the inherited check failure.
- `scripts/validate-contribution.py --base-ref upstream/main` passes for the single new source repository. Scanner CI is reported as not detected and queued for the advisory centralized scan, consistent with the current guide.
- An official MCP SDK stdio smoke test against `@vostride/agent-qa-mcp@0.1.21` discovers 33 tools and validates schema/ID operations, resources, and prompts. This check makes no model-provider or dashboard API calls; it does not attest to a specific assistant client's setup or a full application test run.
- New URLs and `git diff --check` pass; duplicate search matches #72 and #124 are unrelated Cargo Skills and Oh My Design submissions.

The CLI installs as `agent-qa` and requires Node.js 24+. Full MCP authoring/run/triage workflows need the Agent QA dashboard API. The source is available under FSL-1.1-ALv2.

[Repository](https://github.com/vostride/agent-qa) · [Documentation](https://vostride.com/docs/agent-qa) · [License](https://github.com/vostride/agent-qa/blob/main/LICENSE.md)

Disclosure: This is an affiliated Agent QA/Vostride submission.
