### PR TITLE
Add career-ops (Tools & Integrations)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
   "source": "awesome-ai-plugins",
-  "last_updated": "2026-09-04",
+  "last_updated": "2026-09-05",
   "plugins": [
     {
       "name": "Registry Broker",
@@ -4713,6 +4713,21 @@
       "repo": "cadence-code",
       "url": "https://github.com/michael-L-i/cadence-code",
       "install_url": "https://raw.githubusercontent.com/michael-L-i/cadence-code/HEAD/.codex-plugin/plugin.json"
+    },
+    {
+      "name": "career-ops",
+      "displayName": "career-ops",
+      "description": "Open-source AI job search that runs locally inside any AI coding CLI (Claude Code, Codex, OpenCode and others): evaluates offers against your CV, tailors ATS-ready PDFs, tracks every application, and leaves every decision to you",
+      "category": "Tools & Integrations",
+      "source": "awesome-ai-plugins",
+      "platform": "codex",
+      "ecosystems": [
+        "codex"
+      ],
+      "owner": "career-ops-hq",
+      "repo": "career-ops",
+      "url": "https://github.com/career-ops-hq/career-ops",
+      "install_url": "https://raw.githubusercontent.com/career-ops-hq/career-ops/HEAD/.codex-plugin/plugin.json"
     },
     {
       "name": "Cargo Skills",

--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Cadence Code](https://github.com/michael-L-i/cadence-code) - Fully local voice conversations for Claude Code, Codex, Cursor, and Antigravity on Apple Silicon, with selectable MLX speech and transcription models.
 - [Call-E](https://github.com/CALLE-AI/call-e-integrations) - Plan, run, and inspect Call-E phone call workflows from Codex through the calle CLI.
 - [Canvas Apps Plugin Codex](https://github.com/Ratnam-Mishra/canvas-apps-plugin-codex) - Build and edit Microsoft Power Apps Canvas Apps using natural language and Canvas Authoring MCP server.
+- [career-ops](https://github.com/career-ops-hq/career-ops) - Open-source AI job search that runs locally inside any AI coding CLI (Claude Code, Codex, OpenCode and others): evaluates offers against your CV, tailors ATS-ready PDFs, tracks every application, and leaves every decision to you.
 - [Cargo Skills](https://github.com/getcargohq/cargo-skills) - GTM engineering for coding agents — 17 skills over the Cargo CLI for lead sourcing, contact enrichment and email verification, lead scoring, CRM sync, buying-signal monitoring, and workspace-as-code.
 - [CarsXE](https://github.com/carsxe/carsxe-codex-plugin) - Decode VINs, license plates, market value, vehicle history, recalls, liens, OBD codes, and more via the CarsXE API.
 - [Chrome DevTools](https://github.com/win4r/chrome-devtools-codex-plugin) - One-click Codex plugin wrapper for chrome-devtools-mcp.

--- a/plugins.json
+++ b/plugins.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "name": "awesome-ai-plugins",
   "version": "1.0.0",
-  "last_updated": "2026-09-04",
-  "total": 334,
+  "last_updated": "2026-09-05",
+  "total": 335,
   "platforms": [
     "codex",
     "grok",
@@ -4404,6 +4404,20 @@
       "platform": "codex",
       "source": "awesome-ai-plugins",
       "install_url": "https://raw.githubusercontent.com/michael-L-i/cadence-code/HEAD/.codex-plugin/plugin.json",
+      "ecosystems": [
+        "codex"
+      ]
+    },
+    {
+      "name": "career-ops",
+      "url": "https://github.com/career-ops-hq/career-ops",
+      "owner": "career-ops-hq",
+      "repo": "career-ops",
+      "description": "Open-source AI job search that runs locally inside any AI coding CLI (Claude Code, Codex, OpenCode and others): evaluates offers against your CV, tailors ATS-ready PDFs, tracks every application, and leaves every decision to you",
+      "category": "Tools & Integrations",
+      "platform": "codex",
+      "source": "awesome-ai-plugins",
+      "install_url": "https://raw.githubusercontent.com/career-ops-hq/career-ops/HEAD/.codex-plugin/plugin.json",
       "ecosystems": [
         "codex"
       ]


### PR DESCRIPTION
Adds career-ops to Tools & Integrations, alphabetically between Canvas Apps Plugin Codex and Cargo Skills.

- An open-source AI job search (MIT, 55K+ stars) that runs locally inside any AI coding CLI (Claude Code, Codex, OpenCode and others): evaluates offers against your CV, tailors ATS-ready PDFs, tracks every application, and leaves every decision to you.
- plugins.json and .agents/plugins/marketplace.json regenerated with scripts/generate_plugins_json.py; scripts/validate-contribution.py passes. The pre-existing alphabetical failure in Development & Workflow is untouched by this PR.

Requested by the awesome-ai-plugins maintainers in our issue #3402.
