### PR TITLE
Add YYLO to Development & Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Wingman](https://github.com/lsshym/wingman.ai) - Cross-platform AI coding-agent plugin for repo-local project memory, data-contract checks, and project-map discovery before agents edit code.
 - [Workflow Kit](https://github.com/Le-Xuan-Thang/workflow-kit) - Full product lifecycle plugin for Claude Code, Codex CLI, and OpenCode: define Vision/Mission/Core → generate workplan → execute with mandatory cross-provider reviewer agents → synthesize deliverables → maintain, with parallel task execution, crash recovery, and AgentOps metrics.
 - [Writer's Loop](https://github.com/xxsang/writers-loop) - Structured AI writing workflow for planning, critique, revision, translation, style distillation, and opt-in local preference learning.
+- [YYLO](https://github.com/yylo-dev/yylo) - Command-line orchestrator for coding agents that creates a dedicated branch/worktree per task, delegates to Pi and Codex subagents, and enforces typed task, validation, merge, and release-readiness boundaries with receipt-backed repository changes.
 - [Zagrosi Forge](https://github.com/zagrosi-code/zagrosi-forge) - Decompose broad project briefs into researched plans and implement sectioned work with TDD, quality gates, and traceability.
 
 ### Tools & Integrations


### PR DESCRIPTION
Adds [YYLO](https://github.com/yylo-dev/yylo) to **Community Plugins → Development & Workflow**, alphabetically between `Writer's Loop` and `Zagrosi Forge` (one line, CONTRIBUTING.md format).

**What it is:** YYLO is a command-line orchestrator for coding agents, repeatable workflows, and receipt-backed repository changes. `task start` creates a dedicated branch/worktree per task, work is delegated to Pi and Codex subagents, and a merge queue owns risk-based review with typed task, validation, merge, and release-readiness boundaries.

- Repo: https://github.com/yylo-dev/yylo
- License: MIT
- Distribution: npm ([`@yylo/cli`](https://www.npmjs.com/package/%40yylo%2Fcli)), commands `yylo` / `yy`
- Actively maintained (daily pushes since January 2026)

**Format checks (run locally against this branch):**
- `python3 scripts/validate-contribution.py --base-ref upstream/main` → "All 1 contribution entry passed catalog validation." (scanner CI `not_detected` — understood to be optional/advisory per CONTRIBUTING.md)
- The entry itself is placed in correct alphabetical position.
- Heads-up: `scripts/check-alphabetical.py` reports `Development & Workflow` as unsorted, but that failure pre-exists on `main` — it comes from the vendored `./plugins/mturac/*` entries (Commit Narrator, Deps Doctor, Env Lint, Flaky Detector, PR Storyteller, Test Gap, TODO Harvest), which sit out of alphabetical order and can't be reordered from a contributor PR (moving them makes them "added" lines that fail the catalog format check). Happy to leave that for a maintainer-side fix; I deliberately kept this PR to the single added line.

**Disclosure:** I'm on the team that builds YYLO; this PR was prepared with AI assistance and reviewed by a human maintainer. Every description phrase is quoted from the project's README.

**Verification:** installed and used daily (`yy` / `yylo` on npm); repo has continuous commits since 2026-01-06.
