### PR TITLE
Add ParlayAPI MCP server to Tools and Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [OrgX](https://github.com/useorgx/orgx-codex-plugin) - MCP access and initiative-aware skills for organizational workflows.
 - [PANews Agent Toolkit](https://github.com/panewslab/skills) - Crypto and blockchain news discovery, authenticated creator publishing workflows, and page-to-Markdown reading.
 - [PapersFlow](https://github.com/papersflow-ai/papersflow-codex-plugin) - Paper discovery, citation verification, graph exploration, and DeepScan analysis.
+- [ParlayAPI](https://github.com/JacobiusMakes/parlay-api-mcp) - Python MCP server for sports odds, player props, public event discovery, and account usage; account data tools require your own API key and allowances.
 - [PDF Monster](https://github.com/jbaehova/pdf-monster) - Analyzes PDFs as extracted text, OCR text, rendered page images, and embedded figures for coding agents.
 - [plori](https://github.com/plori-ai/codex-plugin) - Create and drive plori cloud agents (each an AI agent on its own cloud computer) over plori's remote MCP server, with OAuth auto-discovery.
 - [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) - Route image-generation prompts to 30+ models (DALL-E, Stable Diffusion, Flux, Midjourney, and more) through a single MCP interface. Install: `npm install -g prompt-to-asset`.


### PR DESCRIPTION
Adds ParlayAPI under Community Plugins / Tools & Integrations. The public Python MCP server exposes sports odds, player props, public event discovery, and account usage; account data tools require each user's own API key and allowances.

Verification:
- Published 0.3.5 metadata-only startup with `uvx --from parlayapi-mcp==0.3.5 parlayapi-mcp` discovered 22 tools without an API key or tool calls.
- The catalog's `validate-contribution.py` passed the new entry against the reachable public repository; scanner inspection was advisory/unknown in the local runtime.
- Tools & Integrations passes the alphabetical check (109 entries), and `git diff --check` passes.

The full alphabetical check also fails on unchanged main: Development & Workflow is already out of order. This one-line PR leaves those unrelated entries untouched. No native-client certification is claimed.
