### PR TITLE
Fix catalog ordering validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,18 +170,18 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Codex Skin Pack Installer](https://github.com/ChannelerH/codex-skin-packs) - Codex plugin and Skill that stages verified desktop skin packs from GitHub releases, validates files, and keeps restore guidance visible.
 - [Codex TUI Proof](https://github.com/bnc4vk/codex-tui-proof) - Visually validate real local terminal UIs in Codex's in-app browser with screenshots and session evidence.
 - [Codex Usage and Resets](https://github.com/joelfarthing/codex-usage-and-resets) - Turns Codex usage into planning facts with linear pace, projected exhaustion, banked-reset expirations, and conservative unexpected-reset detection.
-- [Commit Narrator](./plugins/mturac/commit-narrator) - Generate semantic commit message from staged diff, including the _why_.
 - [codex-profiles](https://github.com/Ducksss/codex-profiles) - Switch Codex CLI and Desktop accounts with isolated `CODEX_HOME` profile directories instead of copying token files.
 - [coffee-paladin](https://github.com/pawelkwaczynski/coffee-paladin) - Thermal guard for Apple Silicon: pauses hot jobs before the Mac throttles and gates Claude Code, Codex and Gemini CLI before heavy commands.
+- [Commit Narrator](./plugins/mturac/commit-narrator) - Generate semantic commit message from staged diff, including the _why_.
 - [Contexo](https://github.com/maheedhar132/Contexo) - Portable AI context and cost control across every AI coding harness.
 - [Context Guard](https://github.com/GreenLv/codex-context-guard) - Preserves authoritative requirements and verification evidence across long-running Codex tasks and context compaction.
 - [Contorium](https://github.com/ContoriumLabs/contorium) - Runtime continuity layer for AI coding agents, providing persistent workspace state, Git-aware sessions, and MCP-based context retrieval across tools and agent runs.
 - [Coordinate Agents](https://github.com/hogancv/coordinate-agents) - Plugin-first multi-agent coordination tool with a local-first, recoverable Agent Bus and human-gated planning, implementation, review, and release workflows.
 - [Cover My Repo](https://github.com/sjh9714/cover-my-repo) - Designs three checked GitHub social preview cards with Codex or Cursor, then renders them locally with Chrome.
 - [debt-ops](https://github.com/bcanfield/agentic-tech-debt) - Catches AI-introduced tech debt at write-time: hooks log every deferral to a registry in your repo and a review skill ranks paydown by file churn.
-- [Deps Doctor](./plugins/mturac/deps-doctor) - Multi-ecosystem dependency audit (npm, pip, cargo, go) in one report.
 - [Delx Recovery](https://github.com/davidmosiah/delx-plugins) - Free recovery and continuity plugin for AI agents: resume prior sessions, capture state, process failures into a recovery plan, and remember across sessions through a hosted MCP server (works in Codex, Claude Code, Cursor, and VS Code).
 - [Dely](https://github.com/hieuphung97/dely) - Multi-harness control protocol that turns requests into approved design contracts, orchestrating isolated worker sessions for sequential implementation and independent code reviews under Orca supervision for Claude Code, Codex, Cursor, Antigravity, and other AI coding agents.
+- [Deps Doctor](./plugins/mturac/deps-doctor) - Multi-ecosystem dependency audit (npm, pip, cargo, go) in one report.
 - [Designer Skill](https://github.com/Pythoughts-labs/designer-skill) - Plug-and-play MCP that gives your agent UI superpowers. One install: design skill + MCP server, zero config.
 - [Dev Skills](https://github.com/Jason-chen-coder/dev-skills) - Team workflow skills for specs, plans, TDD, debugging, verification, review, branch finishing, and design context.
 - [dev-harness-kit](https://github.com/sh-ai-x/dev-harness-kit) - Enforced development workflow skills for Codex and Claude Code covering planning, TDD, debugging, review, security, CI, and release.
@@ -192,13 +192,13 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [dsh-whale-musume](https://github.com/Sutera-Diffusus/dsh-whale-musume) - Whale-girl desktop pet for the DSH Web UI with pat-to-raise growth, work-state poses, 494 dialogue lines, 30 achievements and a built-in settings panel; local-first, zero telemetry.
 - [ejentum-mcp](https://github.com/ejentum/ejentum-mcp) - MCP server exposing reasoning, code, anti-deception, and memory harness tools for Codex.
 - [Embedded Workbench](https://github.com/AmethystLuna/embedded-workbench) - Embedded C/C++ firmware development toolbox — 7 skills (FreeRTOS, Keil MDK, ARMCLANG, HardFault triage, state machines, LVGL) plus workflow gates and 4 agents for Claude Code, Codex, Cursor, Kimi, OpenCode, and ZCode.
-- [Env Lint](./plugins/mturac/env-lint) - `.env` vs `.env.example` key parity — never prints values.
 - [Encore Lite](https://github.com/keegan-dotcom/encore-lite) - Free end-of-week surprise builder for Claude Code and Codex - the night before your weekly usage cap resets, it reads your recent work and builds one bonus deliverable, delivered as a reveal with an optional weekly scheduled run.
+- [Env Lint](./plugins/mturac/env-lint) - `.env` vs `.env.example` key parity — never prints values.
 - [Epic Harness](https://github.com/epicsagas/epic-harness) - Auto-trigger quality skills + self-evolving agent harness — orbit (spec-to-ship), evolve (skill mutation), team (multi-agent), TDD, check, ship, simplify, debug, perf, secure.
 - [Espresso](https://github.com/mirkobozzetto/espresso) - Full token-saving stack in one plugin - output compression, global rules, RTK hook, Caveman ultra, GitNexus config. Detects existing setup, installs only what's missing. Works on Claude Code and Codex.
 - [falsegreen-skill](https://github.com/vinicq/falsegreen-skill) - Finds tests that stay green when the code they cover is broken, applying six ordered judgments over Python, TypeScript, JavaScript, and Robot Framework suites in Codex CLI and Claude Code.
-- [Flaky Detector](./plugins/mturac/flaky-detector) - Run a test command N times, report per-test flakiness %.
 - [FinBridge](https://github.com/Jakechj/finbridge-mcp) - Remote MCP server for Korean and US market data with filings, screeners, insider activity, and portfolio backtests.
+- [Flaky Detector](./plugins/mturac/flaky-detector) - Run a test command N times, report per-test flakiness %.
 - [FlexViz](https://github.com/flex-analytics/flexviz) - Interactive cross-filter dashboards for large datasets with a Claude Code skill for agent-driven data exploration.
 - [Frappe Agent](https://github.com/Dkm0315/frappe-agent) - Frappe and ERPNext coding, customization, bench, and review intelligence for Codex.
 - [GCF Proxy](https://github.com/blackwell-systems/gcf-codex-plugin) - Save 71% on MCP tool call tokens by wrapping any server with GCF encoding, with session stats hook and setup skill.
@@ -262,8 +262,8 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [OpenCode Power Pack](https://github.com/waybarrios/opencode-power-pack) - Fifty-four portable development and security workflows for Codex, Claude Code, OpenCode, and Pi, with opt-in native sandbox profiles for safer command execution.
 - [pbx-mcp](https://github.com/ictinnovations/pbx-mcp) - MCP server for Asterisk (AMI) and FreeSWITCH (ESL). Inspect channels, SIP registrations, trunks, and dialplan on a live PBX.
 - [Personal Data Protection](https://github.com/AltByteSG/personal-data-protection-skill) - Engineer-facing personal-data-protection compliance reference — Singapore PDPA, Thailand PDPA, Indonesia UU PDP, Malaysia PDPA (Act 709 + 2024 Amendments), Philippines DPA — organised by where in the stack each obligation lands, with checklists, breach-response runbook, and a developer-view divergence table across all five.
-- [PR Storyteller](./plugins/mturac/pr-storyteller) - PR title + body + test plan from commits and diff vs base branch.
 - [Planning with Files](https://github.com/OthmanAdi/planning-with-files) - Persistent file-based planning for Claude Code, Codex, and other AI coding agents, preserving task plans, findings, and progress across context loss, crashes, and compaction.
+- [PR Storyteller](./plugins/mturac/pr-storyteller) - PR title + body + test plan from commits and diff vs base branch.
 - [Praxis](https://github.com/ouonet/praxis) - Intent-driven workflow skills for coding agents: describe what done looks like, not the steps. Triage-first design keeps token costs low across design, TDD, debug, review, and release.
 - [Project Autopilot](https://github.com/AlexMi64/codex-project-autopilot) - Turn an idea into a structured project workflow with planning, execution, verification, and handoff.
 - [pstack for Codex](https://github.com/Aqua-123/pstack-for-codex) - Codex-native engineering workflows derived from pstack, with 45 explicit skills and 23 Poteto Mode playbooks.
@@ -301,10 +301,10 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Tartiner Labs](https://github.com/tartinerlabs/skills) - Agent skills for git workflows, GitHub automation, security audits, code refactoring, and project tooling.
 - [taskflow](https://github.com/heggria/taskflow) - Declarative, verifiable DAG orchestration for Grok Build subagents — fan-out, gates, loops, tournaments, approvals, and resumable runs via MCP tools, with intermediate transcripts kept out of context.
 - [Team Skills Platform](https://github.com/Colin4k1024/tsp) - Role-based team delivery framework — Tech Lead-orchestrated 8-role system with 195+ skills, 27 specialist agents, 80+ commands, hooks, and ECC harness for Claude Code, Codex, and OpenCode.
-- [Test Gap](./plugins/mturac/test-gap) - Find lines in your diff lacking test coverage (Cobertura, lcov, coverage.json).
-- [TODO Harvest](./plugins/mturac/todo-harvest) - TODO/FIXME/HACK scan with `git blame` author + age.
 - [TermaGITchi](https://github.com/TevvvB/termagitchi) - Stable per-worktree identity for parallel Claude Code, Codex, and tmux sessions; mood reads repository hygiene, not what the agent is doing.
+- [Test Gap](./plugins/mturac/test-gap) - Find lines in your diff lacking test coverage (Cobertura, lcov, coverage.json).
 - [ThumbGate](https://github.com/IgorGanapolsky/ThumbGate) - Pre-action infrastructure firewall for AI coding agents: feedback becomes lessons and prevention rules enforced by PreToolUse hooks across Claude Code, Codex, Gemini, and MCP.
+- [TODO Harvest](./plugins/mturac/todo-harvest) - TODO/FIXME/HACK scan with `git blame` author + age.
 - [token-optimizer](https://github.com/ooples/token-optimizer-mcp) - Spend less context and keep the conclusions across 16 coding clients including Claude Code, Codex, Gemini CLI, Cursor, and Copilot — diff-only re-reads, paths-only search, out-of-context stashing, and a local ledger that measures each tool's actual return.
 - [Tool Advisor](https://github.com/dragon1086/claude-skills) - Read-only meta-skill that scans your MCP servers, skills, plugins, and CLI tools, then suggests up to three ranked approaches (Methodical / Fast / Deep) with a copy-paste Quick Action table.
 - [trace-mcp](https://github.com/nikolai-vysotskyi/trace-mcp) - Precomputed code-intelligence graph served over MCP — symbol search, call graphs, change impact, and test mapping as structured answers instead of whole-file reads.

--- a/scripts/validate-contribution.py
+++ b/scripts/validate-contribution.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+from collections import Counter
 import difflib
 import json
 import os
@@ -411,13 +412,19 @@ def malformed_community_plugin_lines(
     if not diff:
         return []
     base_lines = base_readme.splitlines()
-    existing_community_lines = {
+    base_community_lines = Counter(
         line.strip()
         for number, line in enumerate(base_lines, start=1)
         if current_readme_section(base_lines, number) == "Community Plugins"
         and line.strip().startswith("- [")
-    }
+    )
     readme_lines = head_readme.splitlines()
+    head_community_lines = Counter(
+        line.strip()
+        for number, line in enumerate(readme_lines, start=1)
+        if current_readme_section(readme_lines, number) == "Community Plugins"
+        and line.strip().startswith("- [")
+    )
     malformed: list[str] = []
     added_line_number = 0
     for line in diff.splitlines():
@@ -430,7 +437,7 @@ def malformed_community_plugin_lines(
             if (
                 current_readme_section(readme_lines, added_line_number) == "Community Plugins"
                 and content.startswith("- [")
-                and content not in existing_community_lines
+                and head_community_lines[content] > base_community_lines[content]
                 and README_ENTRY_RE.match(content) is None
             ):
                 malformed.append(content)

--- a/scripts/validate-contribution.py
+++ b/scripts/validate-contribution.py
@@ -396,11 +396,27 @@ def inspect_scanner_ci(contribution: Contribution) -> ScannerCiInspection:
     )
 
 
-def malformed_community_plugin_lines(diff: str, head_readme: str) -> list[str]:
-    """Return added Community Plugins bullets that do not match the catalog format."""
+def malformed_community_plugin_lines(
+    diff: str,
+    base_readme: str,
+    head_readme: str,
+) -> list[str]:
+    """Return new Community Plugins bullets that do not match the catalog format.
+
+    Exact lines already present in the base README may appear as additions when
+    an existing entry is reordered. They are not new submissions and should not
+    be rejected for using a legacy or repository-local URL format.
+    """
 
     if not diff:
         return []
+    base_lines = base_readme.splitlines()
+    existing_community_lines = {
+        line.strip()
+        for number, line in enumerate(base_lines, start=1)
+        if current_readme_section(base_lines, number) == "Community Plugins"
+        and line.strip().startswith("- [")
+    }
     readme_lines = head_readme.splitlines()
     malformed: list[str] = []
     added_line_number = 0
@@ -414,6 +430,7 @@ def malformed_community_plugin_lines(diff: str, head_readme: str) -> list[str]:
             if (
                 current_readme_section(readme_lines, added_line_number) == "Community Plugins"
                 and content.startswith("- [")
+                and content not in existing_community_lines
                 and README_ENTRY_RE.match(content) is None
             ):
                 malformed.append(content)
@@ -507,7 +524,7 @@ def entries_for_open_pull_request(repository: str, pull_request: OpenPullRequest
             tofile="README.md",
         )
     )
-    malformed = malformed_community_plugin_lines(diff, head_readme)
+    malformed = malformed_community_plugin_lines(diff, base_readme, head_readme)
     if malformed:
         raise ValidationError(
             "Community Plugins entries must use `- [Name](https://github.com/owner/repo) - description`: "
@@ -743,8 +760,9 @@ def main() -> int:
         return 1
 
     diff = git("diff", args.base_ref, "--", "README.md")
+    base_readme = git("show", f"{args.base_ref}:README.md")
     head_readme = README_PATH.read_text(encoding="utf-8") if README_PATH.exists() else ""
-    malformed = malformed_community_plugin_lines(diff, head_readme)
+    malformed = malformed_community_plugin_lines(diff, base_readme, head_readme)
     if malformed:
         print("ERROR: malformed Community Plugins entries:", file=sys.stderr)
         for line in malformed:

--- a/scripts/validate-contribution.py
+++ b/scripts/validate-contribution.py
@@ -404,9 +404,10 @@ def malformed_community_plugin_lines(
 ) -> list[str]:
     """Return new Community Plugins bullets that do not match the catalog format.
 
-    Exact lines already present in the base README may appear as additions when
-    an existing entry is reordered. They are not new submissions and should not
-    be rejected for using a legacy or repository-local URL format.
+    Exact lines already present in the base Community Plugins section may appear
+    as additions when an existing entry is reordered. They are not new
+    submissions and should not be rejected for using a legacy or
+    repository-local URL format.
     """
 
     if not diff:

--- a/tests/test-validate-contribution.py
+++ b/tests/test-validate-contribution.py
@@ -180,6 +180,22 @@ class ValidateContributionTests(unittest.TestCase):
 
         self.assertEqual(malformed, [local_entry])
 
+    def test_local_entry_moved_from_another_section_is_malformed(self) -> None:
+        local_entry = "- [Local Plugin](./plugins/local) - bundled plugin"
+        base = f"## Contents\n{local_entry}\n## Community Plugins\n"
+        head = f"## Contents\n## Community Plugins\n{local_entry}\n"
+        diff = (
+            "@@ -1,3 +1,3 @@\n"
+            " ## Contents\n"
+            f"-{local_entry}\n"
+            " ## Community Plugins\n"
+            f"+{local_entry}\n"
+        )
+
+        malformed = MODULE.malformed_community_plugin_lines(diff, base, head)
+
+        self.assertEqual(malformed, [local_entry])
+
     def test_relocated_entry_is_detected_when_base_url_only_exists_in_contents(self) -> None:
         base = (
             "## Contents\n"

--- a/tests/test-validate-contribution.py
+++ b/tests/test-validate-contribution.py
@@ -151,6 +151,35 @@ class ValidateContributionTests(unittest.TestCase):
 
         self.assertEqual(malformed, [changed_entry])
 
+    def test_duplicate_existing_local_entry_is_still_malformed(self) -> None:
+        local_entry = "- [Local Plugin](./plugins/local) - bundled plugin"
+        base = f"## Community Plugins\n{local_entry}\n"
+        head = f"## Community Plugins\n{local_entry}\n{local_entry}\n"
+        diff = (
+            "@@ -1,2 +1,3 @@\n"
+            " ## Community Plugins\n"
+            f" {local_entry}\n"
+            f"+{local_entry}\n"
+        )
+
+        malformed = MODULE.malformed_community_plugin_lines(diff, base, head)
+
+        self.assertEqual(malformed, [local_entry])
+
+    def test_new_local_entry_is_malformed(self) -> None:
+        local_entry = "- [Local Plugin](./plugins/local) - bundled plugin"
+        base = "## Community Plugins\n"
+        head = f"## Community Plugins\n{local_entry}\n"
+        diff = (
+            "@@ -1,1 +1,2 @@\n"
+            " ## Community Plugins\n"
+            f"+{local_entry}\n"
+        )
+
+        malformed = MODULE.malformed_community_plugin_lines(diff, base, head)
+
+        self.assertEqual(malformed, [local_entry])
+
     def test_relocated_entry_is_detected_when_base_url_only_exists_in_contents(self) -> None:
         base = (
             "## Contents\n"

--- a/tests/test-validate-contribution.py
+++ b/tests/test-validate-contribution.py
@@ -108,8 +108,48 @@ class ValidateContributionTests(unittest.TestCase):
             " ## Community Plugins\n"
             "+- [Broken Plugin](https://example.com/not-github) - not a github repo\n"
         )
-        malformed = MODULE.malformed_community_plugin_lines(diff, head)
+        malformed = MODULE.malformed_community_plugin_lines(diff, "", head)
         self.assertEqual(len(malformed), 1)
+
+    def test_reordered_existing_local_entry_is_not_malformed(self) -> None:
+        local_entry = "- [Local Plugin](./plugins/local) - bundled plugin"
+        base = (
+            "## Community Plugins\n"
+            f"{local_entry}\n"
+            "- [Alpha](https://github.com/example/alpha) - first\n"
+        )
+        head = (
+            "## Community Plugins\n"
+            "- [Alpha](https://github.com/example/alpha) - first\n"
+            f"{local_entry}\n"
+        )
+        diff = (
+            "@@ -1,3 +1,3 @@\n"
+            " ## Community Plugins\n"
+            f"-{local_entry}\n"
+            " - [Alpha](https://github.com/example/alpha) - first\n"
+            f"+{local_entry}\n"
+        )
+
+        malformed = MODULE.malformed_community_plugin_lines(diff, base, head)
+
+        self.assertEqual(malformed, [])
+
+    def test_modified_local_entry_is_still_malformed(self) -> None:
+        base_entry = "- [Local Plugin](./plugins/local) - bundled plugin"
+        changed_entry = "- [Local Plugin](./plugins/renamed) - bundled plugin"
+        base = f"## Community Plugins\n{base_entry}\n"
+        head = f"## Community Plugins\n{changed_entry}\n"
+        diff = (
+            "@@ -1,2 +1,2 @@\n"
+            " ## Community Plugins\n"
+            f"-{base_entry}\n"
+            f"+{changed_entry}\n"
+        )
+
+        malformed = MODULE.malformed_community_plugin_lines(diff, base, head)
+
+        self.assertEqual(malformed, [changed_entry])
 
     def test_relocated_entry_is_detected_when_base_url_only_exists_in_contents(self) -> None:
         base = (


### PR DESCRIPTION
## Summary

- restore alphabetical order in the Community Plugins catalog
- allow exact reorders of existing repository-local entries without treating them as new malformed submissions
- keep rejecting new, modified, duplicated, or cross-section-moved local-format entries

## Why

Concurrent catalog merges left `main` out of order, which makes the alphabetical and contribution-requirements checks fail for unrelated submissions. Re-sorting exposed a validator edge case: Git represents moved local entries as additions, and the validator rejected those existing entries as malformed.

This repair unblocks open catalog submissions whose merge snapshots inherit the current `main` ordering failure.

## Bootstrap check

The branch-native `alphabetical`, `Check contribution requirements`, and artifact-sync checks pass. The aggregate `Open Plugin Contribution Gate` remains red because its security-conscious workflow checks out the validator from `main`; that older validator rejects the reordered repository-local entries this PR is designed to support. It will only be able to evaluate the repair after the repair reaches `main`.

## Verification

- 17 contribution-validator tests
- 5 marketplace-generator tests
- 4 scanner-action sync tests
- `python scripts/check-alphabetical.py README.md`
- `python -X utf8 scripts/validate-contribution.py --base-ref upstream/main --matrix-output contribution-matrix.json`
- `git diff --check`
