### PR TITLE
Add ZUI Codex plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Workflow Kit](https://github.com/Le-Xuan-Thang/workflow-kit) - Full product lifecycle plugin for Claude Code, Codex CLI, and OpenCode: define Vision/Mission/Core → generate workplan → execute with mandatory cross-provider reviewer agents → synthesize deliverables → maintain, with parallel task execution, crash recovery, and AgentOps metrics.
 - [Writer's Loop](https://github.com/xxsang/writers-loop) - Structured AI writing workflow for planning, critique, revision, translation, style distillation, and opt-in local preference learning.
 - [Zagrosi Forge](https://github.com/zagrosi-code/zagrosi-forge) - Decompose broad project briefs into researched plans and implement sectioned work with TDD, quality gates, and traceability.
+- [zui](https://github.com/easysoft/zui) - Codex skills that integrate the ZUI 3 web UI framework into existing projects and generate standalone ZUI-powered pages from plain briefs.
 
 ### Tools & Integrations
 


### PR DESCRIPTION
Adds [zui](https://github.com/easysoft/zui) to **Community Plugins → Development & Workflow**, following the invitation in https://github.com/easysoft/zui/issues/248.

ZUI's Codex plugin provides two skills: `$zui` integrates ZUI 3 into existing applications, and `$zui-build` creates standalone pages with bundled ZUI assets that run without package installation or build tooling.

Verification:

- `python3 scripts/validate-contribution.py --base-ref origin/main` passed catalog validation for `easysoft/zui`.
- The catalog parser discovers exactly one ZUI entry as a Codex plugin, with the expected category and root `.codex-plugin/plugin.json` installation URL; the public manifest is reachable.
- In the ZUI repository, `pnpm test:skills` passed all four tests.
- Ran `create-zui-page.mjs` with bundled ZUI 3.0.0 resources, then `validate-zui-page.mjs`; validation passed without errors or warnings.
- Opened the generated page directly through a `file://` URL in Chromium. Date-picker initialization, theme switching, message feedback, dropdown navigation, and layout at 1440px and 390px passed, with no page errors or failed resource requests.

Known upstream check failure: `python3 scripts/check-alphabetical.py README.md` reports the same six out-of-order pairs in **Development & Workflow** on both the base revision and this change. ZUI is added in alphabetical order after Zagrosi Forge. This PR leaves the existing entries untouched.

Only `README.md` changes; the repository's existing workflow will synchronize generated catalog artifacts after merge.
