### PR TITLE
Add sci-brain

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [RoadmapSmith](https://github.com/PapiScholz/roadmapsmith) - Evidence-backed ROADMAP.md workflows for AI coding agents with validation, sync, and roadmap generation across any tech stack.
 - [Rootly MCP Server](https://github.com/rootlyhq/rootly-mcp-server) - Manage and resolve production incidents from MCP-compatible AI assistants through dynamically generated, access-controlled Rootly API tools.
 - [Runtype Skills](https://github.com/runtypelabs/skills) - Supercharge your coding agent for AI product development — build, deploy, and operate agents, flows, tools, and surfaces on Runtype's managed edge runtime.
+- [sci-brain](https://github.com/QuantumBFS/sci-brain) - Research skills plugin for Claude Code, Codex, OpenCode, and pi that surveys literature into a citable knowledge base, brainstorms research ideas, and drafts papers and slides.
 - [Sealos](https://github.com/labring/sealos-skills) - Deploy apps to Sealos Cloud from Codex with readiness checks, Dockerfile generation, Compose conversion, image builds, and rollout updates.
 - [Secret Guard](./plugins/mturac/secret-guard) - Pre-commit secret scanner using pattern and entropy detection.
 - [SEO Skills AI](https://github.com/seoskillsai/seo-skills-ai) - Universal SEO skill suite and technical audit engine for Claude Code, Cursor, Codex, and other agents, with first-party Python adapters and HOL plugin-scanner CI.


### PR DESCRIPTION
Adds [sci-brain](https://github.com/QuantumBFS/sci-brain) to Development & Workflow, as requested in QuantumBFS/sci-brain#53. Entry is alphabetical and follows the one-sentence format.

## What sci-brain is

sci-brain is a skills plugin for Claude Code, Codex, OpenCode, and pi that turns a coding agent into a research assistant. It ships 14 `SKILL.md` protocols plus helper scripts. Nothing runs as a server; every skill works on files in the user's project.

The core artifact is a per-project knowledge base at `.knowledge/`: a `references.bib` with verified BibTeX, rendered full-text Markdown for each paper, an auto-generated `INDEX.md`, and human-curated `NOTES.md`. Every citation the agent uses is resolved through CrossRef, Semantic Scholar, or arXiv. BibTeX is never generated from memory.

## Useful for

**Literature survey** (`/survey`). Runs seven search strategies in parallel, lets the user pick directions, then downloads and renders the papers into the knowledge base. From a populated KB it can write a grounded technology or field assessment, where every claim points at a rendered paper. Subsequent brainstorming, paper drafting, and paper review all read from the same KB, so the agent argues from sources on disk rather than from recall.

**Autonomous research** (`/autoresearch`). A four-stage pipeline for problems with a checkable metric. It brainstorms topics scored on checkable, cheap, headroom, and publishable. It builds a domain database and distills insights from the survey. It writes a sealed validator with a hidden holdout and a negative-control self-test. Then it runs attempts in git worktrees, each committed with a log and a JSON report on its own branch, scored by the validator under a time limit. Every hypothesis must state a mechanism and its prior art, and the user authorizes each cycle's direction and attempt budget.

**Ideation, drafting, and review.** `/brainstorm-ideas` is a Socratic mentor that can launch a named advisor subagent grounded in that advisor's own paper collection. `/write-paper` follows a figures-first workflow. `/review-paper` emits location-anchored comments against writing guidelines and verifies references. `/write-slides` builds Typst decks.

## Install

```
/plugin marketplace add QuantumBFS/sci-brain
```

Codex, OpenCode, and pi install instructions are in the repository.
