### PR TITLE
docs: add Everything Claude Code to community plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Env Lint](./plugins/mturac/env-lint) - `.env` vs `.env.example` key parity — never prints values.
 - [Epic Harness](https://github.com/epicsagas/epic-harness) - Auto-trigger quality skills + self-evolving agent harness — orbit (spec-to-ship), evolve (skill mutation), team (multi-agent), TDD, check, ship, simplify, debug, perf, secure.
 - [Espresso](https://github.com/mirkobozzetto/espresso) - Full token-saving stack in one plugin - output compression, global rules, RTK hook, Caveman ultra, GitNexus config. Detects existing setup, installs only what's missing. Works on Claude Code and Codex.
+- [Everything Claude Code (ECC)](https://github.com/affaan-m/ECC) - Cross-harness engineering plugin with 68 agents, 287 skills, 94 commands, hooks, rules, memory, and selective installs for Claude Code, Codex, OpenCode, Cursor, Gemini CLI, and terminal workflows.
 - [falsegreen-skill](https://github.com/vinicq/falsegreen-skill) - Finds tests that stay green when the code they cover is broken, applying six ordered judgments over Python, TypeScript, JavaScript, and Robot Framework suites in Codex CLI and Claude Code.
 - [FinBridge](https://github.com/Jakechj/finbridge-mcp) - Remote MCP server for Korean and US market data with filings, screeners, insider activity, and portfolio backtests.
 - [Flaky Detector](./plugins/mturac/flaky-detector) - Run a test command N times, report per-test flakiness %.


### PR DESCRIPTION
## Summary

- add Everything Claude Code (ECC) to the Development & Workflow catalog
- describe its cross-harness agents, skills, commands, hooks, rules, memory, and selective install support
- preserve alphabetical ordering

Related to https://github.com/affaan-m/ECC/issues/2901

## Verification

- `python3 scripts/check-alphabetical.py README.md`
- `python3 scripts/validate-contribution.py --base-ref upstream/main`
- `git diff --check`
