### PR TITLE
Add ContextStream to Community Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Commit Narrator](./plugins/mturac/commit-narrator) - Generate semantic commit message from staged diff, including the _why_.
 - [Contexo](https://github.com/maheedhar132/Contexo) - Portable AI context and cost control across every AI coding harness.
 - [Context Guard](https://github.com/GreenLv/codex-context-guard) - Preserves authoritative requirements and verification evidence across long-running Codex tasks and context compaction.
+- [ContextStream](https://contextstream.io) - Shared project context for Cursor, Claude Code, Codex, and Grok. Intelligence isn’t the bottleneck. Context is. Remote MCP: https://mcp.contextstream.io/mcp
 - [Contorium](https://github.com/ContoriumLabs/contorium) - Runtime continuity layer for AI coding agents, providing persistent workspace state, Git-aware sessions, and MCP-based context retrieval across tools and agent runs.
 - [Coordinate Agents](https://github.com/hogancv/coordinate-agents) - Plugin-first multi-agent coordination tool with a local-first, recoverable Agent Bus and human-gated planning, implementation, review, and release workflows.
 - [Cover My Repo](https://github.com/sjh9714/cover-my-repo) - Designs three checked GitHub social preview cards with Codex or Cursor, then renders them locally with Chrome.


### PR DESCRIPTION
## Summary
Add ContextStream, a shared project context MCP for Cursor, Claude Code, Codex, and Grok.

- Website: https://contextstream.io
- MCP: https://mcp.contextstream.io/mcp
- Benchmarks: https://contextstream.io/benchmarks
- Pitch: Intelligence isn’t the bottleneck. Context is.

I work on ContextStream. This is a free listing suggestion. $0.

## Test plan
- [ ] Confirm ContextStream was not already listed
- [ ] Confirm the row is in the intended section
- [ ] Confirm links resolve