### PR TITLE
Add TaskDock to Development & Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [tailtest](https://github.com/avansaber/tailtest-codex) - Hook-powered test generation -- detects files changed during an agent turn and instructs Codex to write and run tests automatically. Zero config, 8 languages.
 - [Tandem Workflow Architect](https://github.com/frumu-ai/tandem-codex-plugin) - Plan Tandem workflows in Codex, then validate, preview, and run them through the governed Tandem engine.
 - [Tartiner Labs](https://github.com/tartinerlabs/skills) - Agent skills for git workflows, GitHub automation, security audits, code refactoring, and project tooling.
+- [TaskDock](https://github.com/m1nga/taskdock) - Agent skill for portable task folders with UUID lookup, explicit next actions, and duplicate detection.
 - [taskflow](https://github.com/heggria/taskflow) - Declarative, verifiable DAG orchestration for Grok Build subagents — fan-out, gates, loops, tournaments, approvals, and resumable runs via MCP tools, with intermediate transcripts kept out of context.
 - [Team Skills Platform](https://github.com/Colin4k1024/tsp) - Role-based team delivery framework — Tech Lead-orchestrated 8-role system with 195+ skills, 27 specialist agents, 80+ commands, hooks, and ECC harness for Claude Code, Codex, and OpenCode.
 - [TermaGITchi](https://github.com/TevvvB/termagitchi) - Stable per-worktree identity for parallel Claude Code, Codex, and tmux sessions; mood reads repository hygiene, not what the agent is doing.


### PR DESCRIPTION
## Summary

Adds [TaskDock](https://github.com/m1nga/taskdock) to **Development & Workflow**. TaskDock is an Agent Skill for keeping an ongoing task in a portable folder with a stable UUID, current state, plan, next action, move recovery, duplicate detection, and link checks.

## Verification

- The public repository documents a one-command install: `npx skills add m1nga/taskdock`.
- Its filesystem helper has 16 executable tests covering moves, stale or missing indexes, duplicate identities, existing-file preservation, broken links, bounded searches, symlinks, corrupt metadata, and same-name isolation.
- A reproducible moved-folder demonstration and expected output are published at https://github.com/m1nga/skills/blob/main/docs/try-taskdock.md.
- This catalog entry passed `scripts/check-alphabetical.py` and `scripts/validate-contribution.py` against the current upstream `main`.

This is a skill, not a native plugin package. It does not claim automatic synchronization or background execution. It has not yet been validated by independent community users. Scanner CI is not currently installed; the catalog validator queued the repository for the advisory centralized scan.

I maintain TaskDock. This submission was prepared with AI assistance and checked against the public repository and executable validation evidence.