### PR TITLE
Add opencode-cmd-provider to Tools & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ Third-party plugins built by the community. [PRs welcome](#contributing)!
 - [Nullcost](https://github.com/johnvouros/nullcost-plugin) - Catalog-backed free-tier, free-trial, and cheap developer-tool recommendations for Codex through bundled skills and MCP tools.
 - [OC ChatGPT Multi Auth](https://github.com/ndycode/oc-chatgpt-multi-auth) - Codex setup skill and OpenCode plugin for ChatGPT Plus/Pro OAuth, GPT-5/Codex presets, and multi-account failover.
 - [OpenAI-Compatible Images](https://github.com/Syh1906/openai-compatible-imagegen) - Generate, edit, and batch-process images through OpenAI-compatible APIs using a standalone skill or a Codex App plugin with a canvas for annotating edit requests.
+- [opencode-cmd-provider](https://github.com/rashidrazak/opencode-cmd-provider) - OpenCode plugin that registers Command Code as a provider so you can run its models and plans inside OpenCode, with a sidebar showing tier, allowances, and deal rates.
 - [OpenProject Codex](https://github.com/varaprasadreddy9676/openproject-codex-plugin) - OpenProject integration for Codex with project, team, work package, bulk workflow, boards, wiki, meeting, attachment, and reporting support.
 - [Ophis](https://github.com/ophis-fi/skills) - Onchain token swaps for Codex via the hosted Ophis MCP server, MEV-protected and gasless, built on CoW Protocol.
 - [OrgX](https://github.com/useorgx/orgx-codex-plugin) - MCP access and initiative-aware skills for organizational workflows.


### PR DESCRIPTION
Adds `opencode-cmd-provider` to **Community Plugins → Tools & Integrations**, alphabetically between `OpenAI-Compatible Images` and `OpenProject Codex`.

### What it is

An [OpenCode](https://opencode.ai) plugin and provider that connects OpenCode to the [Command Code](https://commandcode.ai) Provider API, so Command Code plans and models can be used from inside OpenCode. It auto-registers a `provider.commandcode` entry with `[CMD]` models driven by a `COMMANDCODE_API_KEY`, and ships a TUI sidebar showing the active tier, remaining allowances, and current deal rates. It is an unofficial, community-maintained integration and requires the user's own Command Code account.

- Repository: https://github.com/rashidrazak/opencode-cmd-provider
- Package: `opencode-cmd-provider` on npm, currently 1.7.5 (MIT) — install with `opencode plugin opencode-cmd-provider`
- Actively maintained: releases and CI on every change

### Why Tools & Integrations

It is an OpenCode plugin doing provider/auth wiring rather than a skill bundle or workflow pack — the same shape as the neighbouring `OC ChatGPT Multi Auth` entry.

### Verification

- `python3 scripts/check-alphabetical.py README.md` → "All sections are alphabetically sorted."
- The new line matches `README_ENTRY_RE` in `scripts/validate-contribution.py` (single sentence, public GitHub repository URL, correct section).
- The package is published on npm as `opencode-cmd-provider@1.7.5` under MIT, and the repository's CI is green on `main`.
- The project's own e2e suite (`tests/e2e-opencode.mjs`) drives a real `opencode` binary with only the built plugin wired in — no declared provider or models — and asserts that the `commandcode` models are auto-registered. Its streaming leg currently skips on the documented upstream bug (anomalyco/opencode #14956, #5674), so the verified surface is plugin load plus provider auto-registration, not an end-to-end completion.
